### PR TITLE
[샐리] 2021.05.10

### DIFF
--- a/sally/README.md
+++ b/sally/README.md
@@ -1,1 +1,40 @@
 # sally
+
+- 주 언어: C++
+- 하루에 두 문제씩 꾸준히 하자!
+- 메모리, 시간 단축을 위해서 노력하자
+
+---
+
+## Graph Traversal
+
+- [X] **2606_바이러스** / [문제](https://www.acmicpc.net/problem/2606) / [풀이]()
+- [X] **1260_DFS와 BFS**  / [문제](https://www.acmicpc.net/problem/1260) / [풀이]()
+- [ ] 11725_트리의 부모 찾기 / [문제](https://www.acmicpc.net/problem/11725) / [풀이]()
+- [ ] 1325_효율적인 해킹 / [문제](https://www.acmicpc.net/problem/1325) / [풀이]()
+- [ ] 2178_미로 탐색 / [문제](https://www.acmicpc.net/problem/2178) / [풀이]()
+- [ ] 2667_단지번호붙이기 / [문제](https://www.acmicpc.net/problem/2667) / [풀이]()
+- [ ] 7576_토마토 / [문제](https://www.acmicpc.net/problem/7576) / [풀이]()
+- [ ] 7569_토마토 / [문제](https://www.acmicpc.net/problem/7569) / [풀이]()
+- [ ] 16918_봄버맨 / [문제](https://www.acmicpc.net/problem/16918) / [풀이]()
+- [ ] 5547_일루미네이션 / [문제](https://www.acmicpc.net/problem/5547) / [풀이]()
+- [ ] 14502_연구소 / [문제](https://www.acmicpc.net/problem/14502) / [풀이]()
+- [ ] 16234_인구 이동 / [문제](https://www.acmicpc.net/problem/16234) / [풀이]()
+- [ ] 2636_치즈 / [문제](https://www.acmicpc.net/problem/2636) / [풀이]()
+- [ ] 13549_숨바꼭질 3 / [문제](https://www.acmicpc.net/problem/13549) / [풀이]()
+- [ ] 1600_말이 되고픈 원숭이 / [문제](https://www.acmicpc.net/problem/1600) / [풀이]()
+- [ ] 17836_공주님을 구해라! / [문제](https://www.acmicpc.net/problem/17836) / [풀이]()
+- [ ] 16973_직사각형 탈출 / [문제](https://www.acmicpc.net/problem/16973) / [풀이]()
+- [ ] 14940_쉬운 최단거리 / [문제](https://www.acmicpc.net/problem/14940) / [풀이]()
+- [ ] 18513_샘터 / [문제](https://www.acmicpc.net/problem/18513) / [풀이]()
+- [ ] 2668_숫자고르기 / [문제](https://www.acmicpc.net/problem/2668) / [풀이]()
+- [ ] 13023_ABCDE / [문제](https://www.acmicpc.net/problem/13023) / [풀이]()
+- [ ] 16954_움직이는 미로 탈출 / [문제](https://www.acmicpc.net/problem/16954) / [풀이]()
+- [ ] 2206_벽 부수고 이동하기 / [문제](https://www.acmicpc.net/problem/2206) / [풀이]()
+- [ ] 2573_빙산 / [문제](https://www.acmicpc.net/problem/2573) / [풀이]()
+- [ ] 4179_불! / [문제](https://www.acmicpc.net/problem/4179) / [풀이]()
+- [ ] 16932_모양 만들기 / [문제](https://www.acmicpc.net/problem/16932) / [풀이]()
+- [ ] 9466_텀 프로젝트 / [문제](https://www.acmicpc.net/problem/9466) / [풀이]()
+- [ ] 1967_트리의 지름 / [문제](https://www.acmicpc.net/problem/1967) / [풀이]()
+
+---

--- a/sally/graph_traversal/1260_DFS와 BFS(메모리과다).cpp
+++ b/sally/graph_traversal/1260_DFS와 BFS(메모리과다).cpp
@@ -1,0 +1,78 @@
+/*
+Graph Traversal - BFS, DFS
+# Problem: 1260
+# Memory: 21568KB
+# Time: 12ms
+*/
+#include <iostream>
+#include <string>
+#include <vector>
+#include <cmath>
+#include <algorithm>
+#include <queue>
+#include <string.h>
+using namespace std;
+
+int N, M, start_v;
+bool visited[2][1001][10001] = {false, };
+int a, b;
+queue<int> q;
+
+/* DFS func */
+void DFS(int v){
+    cout << v << " ";
+    for(int i = 1; i <= N; i++){
+        if (visited[0][i][v] == true || visited[0][v][i] == true) {
+            if(visited[0][i][i] == false){
+                visited[0][i][v] = visited[0][v][i] = false;
+                visited[0][i][i] = true;
+                DFS(i);
+            }
+        }
+    }
+}
+
+/* BFS func */
+void BFS(){
+    q.push(start_v);
+
+    while(!q.empty()){
+        int cur = q.front();
+        cout << cur << " ";
+        q.pop();
+
+        for(int i = 1; i <= N; i++){
+            if (visited[1][i][cur] == true || visited[1][cur][i] == true)
+            {
+                if (visited[1][i][i] == false)
+                {
+                    visited[1][i][cur] = visited[1][cur][i] = false;
+                    visited[1][i][i] = true;
+                    q.push(i);
+                }
+            }
+        }
+    }
+}
+
+int main(){
+    cin.tie(NULL);
+    ios::sync_with_stdio(false);
+
+    // init
+    cin >> N >> M >> start_v;
+    for(int i = 0; i < M; i++){
+        cin >> a >> b;
+        visited[0][a][b] = visited[0][b][a] = true; // DFS
+        visited[1][a][b] = visited[1][b][a] = true; // BFS
+    }
+
+    visited[0][start_v][start_v] = visited[1][start_v][start_v] = true; 
+
+    DFS(start_v);
+    cout << '\n';
+    BFS();
+    cout << '\n';
+
+    return 0;
+}

--- a/sally/graph_traversal/1260_DFS와 BFS.cpp
+++ b/sally/graph_traversal/1260_DFS와 BFS.cpp
@@ -1,0 +1,74 @@
+/*
+Graph Traversal - BFS, DFS
+# Problem: 1260
+# Memory: 2996KB
+# Time: 4ms
+*/
+#include <iostream>
+#include <string>
+#include <vector>
+#include <cmath>
+#include <algorithm>
+#include <queue>
+#include <string.h>
+using namespace std;
+
+int N, M, start_v;
+bool con[1001][1001] = {false, };
+bool visited[1001] = {false, };
+int a, b;
+queue<int> q;
+
+/* DFS func */
+void DFS(int v){
+    cout << v << ' ';
+
+    for(int i = 1; i <= N; i++){
+        if(v != i && con[i][v] == true && visited[i] == false){
+            visited[i] = true;
+            DFS(i);
+        }
+    }
+}
+
+/* BFS func */
+void BFS(){
+    q.push(start_v);
+
+    while(!q.empty()){
+        int cur = q.front();
+        cout << cur << " ";
+        q.pop();
+
+        for(int i = 1; i <= N; i++){
+            if(cur != i && con[cur][i] == true && visited[i] == false){
+                visited[i] = true;
+                q.push(i);
+            }
+        }
+    }
+}
+
+int main(){
+    cin.tie(NULL);
+    ios::sync_with_stdio(false);
+
+    // init
+    cin >> N >> M >> start_v;
+    for(int i = 0; i < M; i++){
+        cin >> a >> b;
+        con[a][b] = con[b][a] = true;
+    }
+
+    visited[start_v] = true; 
+    DFS(start_v);
+    cout << '\n';
+
+    memset(visited, false, sizeof(visited)); // visit init
+
+    visited[start_v] = true;
+    BFS();
+    cout << '\n';
+
+    return 0;
+}

--- a/sally/graph_traversal/2606_바이러스.cpp
+++ b/sally/graph_traversal/2606_바이러스.cpp
@@ -40,7 +40,7 @@ int main(){
             if(i == cur) continue;
             if (coms[cur][i] == true && coms[i][i] == false) {
                 q.push(i);
-                coms[cur][i] = coms[i][cur] = false;
+                // coms[cur][i] = coms[i][cur] = false;
                 coms[i][i] = true;
                 result++;
             }

--- a/sally/graph_traversal/2606_바이러스.cpp
+++ b/sally/graph_traversal/2606_바이러스.cpp
@@ -1,0 +1,53 @@
+/*
+Graph Traversal - BFS, DFS
+# Problem: 2606
+# Memory: 2028KB
+# Time: 0ms
+*/
+#include <iostream>
+#include <string>
+#include <vector>
+#include <cmath>
+#include <algorithm>
+#include <queue>
+using namespace std;
+
+bool coms[101][101] = {false, };
+int num_com = 0;
+int N = 0;
+int a, b;
+int result = 0;
+queue<int> q;
+
+int main(){
+    cin.tie(NULL);
+    ios::sync_with_stdio(false);
+
+    cin >> num_com >> N;
+    for (int i = 0; i < N; i++) {
+        cin >> a >> b;
+        coms[a][b] = coms[b][a] = true;
+    }
+
+    coms[1][1] = true;
+    q.push(1);
+    
+    while(!q.empty()){
+        int cur = q.front();
+        q.pop();
+
+        for(int i = 1; i <= num_com; i++){
+            if(i == cur) continue;
+            if (coms[cur][i] == true && coms[i][i] == false) {
+                q.push(i);
+                coms[cur][i] = coms[i][cur] = false;
+                coms[i][i] = true;
+                result++;
+            }
+        }
+    }
+    
+    cout << result << '\n';
+
+    return 0;
+}


### PR DESCRIPTION
### 📌 문제 번호

- [바이러스](https://www.acmicpc.net/problem/2606)
- [DFS와 BFS](https://www.acmicpc.net/problem/1260)

---

### 📝 간단한 풀이 과정

#### 2606_바이러스

- 주요변수
  - `bool coms[101][101]` : 노드간 연결 상태를 나타내는 이차원 배열, 대각선은 visited 배열로 사용

- 풀이
  - 1번 노드를 시작노드로 하여 BFS
  - 연결되어있는지, 방문 안했었는지 확인하고 방문
  - 방문 후에는 coms 이차원 배열의 대각 라인에 표시(방문했다고 표시)
  - 방문할 노드를 발견할때마다 result 변수를 +1

#### 1260_DFS와 BFS

- 주요변수
  - `bool con[1001][1001]` : 연결을 나타내는 bool 이차원 배열
  - `bool visited[1001]` : 방문했는지를 표시하는 bool 일차원 배열
  - `queue<int> q` : BFS에 사용되는 큐

- DFS
  - 인자로 들어오는 노드 번호를 출력
  - 1~N까지 반복문을 돌면서 현재 노드와 연결된 노드가 있는지, 그 노드를 방문하였는지 확인
    - (시작노드를 포함한) 방문했던 노드들은 visited true로 초기화했기 때문에 따로 처리하지 않아도 됨(확인하려는 노드가 본인인지)
  - 연결이 되어있고, 노드를 방문하지 않았으면, 방문했다고 표시하고, 재귀를 통해서 다음 노드를 탐색
  - 메모리 면에서 비효율적이지만, 작은 노드 순으로 순회해야한다는 조건 때문에 이차원 배열로 구현
- BFS
  - BFS 시작 전, visited 배열을 초기화
  - 큐가 비어있지 않으면 계속 반복
  - 1~N까지 반복문을 돌면서 현재 노드와 연결된 노드가 있는지, 그 노드를 방문하였는지 확인
    - (시작노드를 포함한) 방문했던 노드들은 visited true로 초기화했기 때문에 따로 처리하지 않아도 됨(확인하려는 노드가 본인인지)
  - 큐에서 뽑은 값을 먼저 출력하고, 이후에 
  - 연결이 되어있고, 노드를 방문하지 않았으면, 방문했다 표시하고, 큐에 넣기

</br>

> 메모리과다 케이스

- 하나의 이차원 배열을 사용해서 문제를 해결하려고 무리한듯
- 배열의 대각선을 노드 visit으로 쓰려고 했는데 전체적으로 맘에 안들어서 갈아엎음

```c
bool visited[2][1001][10001] = {false, };
```

---
