### PR TITLE
[원딜] 2021.06.11

### DIFF
--- a/changwoomon/tree/11725_트리의부모찾기.py
+++ b/changwoomon/tree/11725_트리의부모찾기.py
@@ -1,0 +1,29 @@
+# 11725번: 트리의 부모 찾기
+# https://www.acmicpc.net/problem/11725
+# 메모리/시간: 132912KB / 408ms
+
+import sys
+
+sys.setrecursionlimit(10**9)
+input = sys.stdin.readline
+
+N = int(input())
+
+tree = [[] for _ in range(N+1)]
+answer = [0 for _ in range(N+1)]
+
+for _ in range(N-1):
+    s, e = map(int, input().split())
+    tree[s].append(e)
+    tree[e].append(s)
+
+def dfs(s, parent):
+    for i in tree[s]:
+        if parent[i] == 0:
+            parent[i] = s
+            dfs(i, parent)
+
+dfs(1, answer)
+
+for i in range(2, N+1):
+    print(answer[i])

--- a/changwoomon/tree/11725_트리의부모찾기.py
+++ b/changwoomon/tree/11725_트리의부모찾기.py
@@ -1,11 +1,10 @@
 # 11725번: 트리의 부모 찾기
 # https://www.acmicpc.net/problem/11725
-# 메모리/시간: 49220KB / 420ms
+# 메모리/시간: 49220KB / 376ms
 
 import sys
 from collections import deque
 
-sys.setrecursionlimit(10**9)
 input = sys.stdin.readline
 
 N = int(input())

--- a/changwoomon/tree/11725_트리의부모찾기.py
+++ b/changwoomon/tree/11725_트리의부모찾기.py
@@ -1,8 +1,9 @@
 # 11725번: 트리의 부모 찾기
 # https://www.acmicpc.net/problem/11725
-# 메모리/시간: 132912KB / 408ms
+# 메모리/시간: 49220KB / 420ms
 
 import sys
+from collections import deque
 
 sys.setrecursionlimit(10**9)
 input = sys.stdin.readline
@@ -10,20 +11,23 @@ input = sys.stdin.readline
 N = int(input())
 
 tree = [[] for _ in range(N+1)]
-answer = [0 for _ in range(N+1)]
+parent = [0 for _ in range(N+1)]
 
 for _ in range(N-1):
-    s, e = map(int, input().split())
-    tree[s].append(e)
-    tree[e].append(s)
+    start, end = map(int, input().split())
+    tree[start].append(end)
+    tree[end].append(start)
 
-def dfs(s, parent):
-    for i in tree[s]:
-        if parent[i] == 0:
-            parent[i] = s
-            dfs(i, parent)
+def bfs(start, parent):
+    queue = deque([start])
+    while queue:
+        node = queue.popleft()
+        for i in tree[node]:
+            if parent[i] == 0:
+                queue.append(i)
+                parent[i] = node
 
-dfs(1, answer)
+bfs(1, parent)
 
 for i in range(2, N+1):
-    print(answer[i])
+    print(parent[i])

--- a/changwoomon/tree/9934_완전이진트리.py
+++ b/changwoomon/tree/9934_완전이진트리.py
@@ -1,0 +1,25 @@
+###### 9934번: 완전 이진 트리
+# https://www.acmicpc.net/problem/9934
+# 메모리/시간: 29200KB / 68ms
+
+import sys
+
+input = sys.stdin.readline
+
+K = int(input())
+
+node = list(map(int, input().split()))
+node.insert(0, 0)
+answer = [[] for _ in range(K)]
+
+for i in range(K-1, -1, -1):
+    j = 2**i
+    tmp = []
+    while j < len(node):
+        if node[j] != 0:
+            answer[i].append(node[j])
+            node[j] = 0
+        j += 2**i
+
+for i in range(K-1, -1, -1):
+    print(" ".join(map(str, answer[i])))

--- a/changwoomon/tree/9934_완전이진트리.py
+++ b/changwoomon/tree/9934_완전이진트리.py
@@ -10,16 +10,16 @@ K = int(input())
 
 node = list(map(int, input().split()))
 node.insert(0, 0)
-answer = [[] for _ in range(K)]
+tree = [[] for _ in range(K)]
 
 for i in range(K-1, -1, -1):
     j = 2**i
     tmp = []
     while j < len(node):
         if node[j] != 0:
-            answer[i].append(node[j])
+            tree[i].append(node[j])
             node[j] = 0
         j += 2**i
 
 for i in range(K-1, -1, -1):
-    print(" ".join(map(str, answer[i])))
+    print(" ".join(map(str, tree[i])))


### PR DESCRIPTION
### 📌 푼 문제들

- [완전 이진 트리](https://www.acmicpc.net/problem/9934)
- [트리의 부모 찾기](https://www.acmicpc.net/problem/11725)

---

### 📝 간단한 풀이 과정

#### 9934_완전이진트리

- `node`에 방문한 순서대로 노드를 넣어준다.
- 완전 이진 트리
  - 2^{K-1}: 루트 노드
  - 2^{K-2}의 배수들: 2층 노드들 + 루트 노드
  - 2^{K-3}의 배수들: 3층 노드들 + 2층 노드들 + 루트 노드
→ 규칙을 토대로 노드들을 트리에 넣어주며 트리를 만들어준다. (이미 트리에 들어간 노드는 0으로 만들어줘 다시 넣어주는 일을 방지)
- 만든 트리를 출력한다.

#### 11725_트리의부모찾기

- 전에 이 문제를 풀었을 때는 DFS를 사용했어서 이번에는 BFS를 사용해봤다.
- 트리의 노드들을 BFS로 돌며 해당 노드에서 갈 수 있는 다른 노드의 parent가 0일 때 현재 노드를 부모로 넣어준다.

---