### PR TITLE
[샐리] 2021.06.11

### DIFF
--- a/sally/README.md
+++ b/sally/README.md
@@ -63,8 +63,8 @@
 
 ## Tree
 
-- [ ] 9934_완전 이진 트리 / [문제](https://www.acmicpc.net/problem/9934) / [풀이]()
-- [ ] 11725_트리의 부모 찾기	 / [문제](https://www.acmicpc.net/problem/11725) / [풀이]()
+- [X] **9934_완전 이진 트리** / [문제](https://www.acmicpc.net/problem/9934) / [풀이]()
+- [X] **11725_트리의 부모 찾기** / [문제](https://www.acmicpc.net/problem/11725) / [풀이]()
 - [ ] 1991_트리 순회 / [문제](https://www.acmicpc.net/problem/1991) / [풀이]()
 - [ ] 5639_이진 검색 트리	 / [문제](https://www.acmicpc.net/problem/5639) / [풀이]()
 - [ ] 1068_트리/ [문제](https://www.acmicpc.net/problem/1068) / [풀이]()

--- a/sally/README.md
+++ b/sally/README.md
@@ -61,3 +61,15 @@
 
 ---
 
+## Tree
+
+- [ ] 9934_완전 이진 트리 / [문제](https://www.acmicpc.net/problem/9934) / [풀이]()
+- [ ] 11725_트리의 부모 찾기	 / [문제](https://www.acmicpc.net/problem/11725) / [풀이]()
+- [ ] 1991_트리 순회 / [문제](https://www.acmicpc.net/problem/1991) / [풀이]()
+- [ ] 5639_이진 검색 트리	 / [문제](https://www.acmicpc.net/problem/5639) / [풀이]()
+- [ ] 1068_트리/ [문제](https://www.acmicpc.net/problem/1068) / [풀이]()
+- [ ] 6416_트리인가?/ [문제](https://www.acmicpc.net/problem/6416) / [풀이]()
+- [ ] 14675_단절점과 단절선 / [문제](https://www.acmicpc.net/problem/14675) / [풀이]()
+- [ ] 17073_나무 위의 빗물 / [문제](https://www.acmicpc.net/problem/17073) / [풀이]()
+
+---

--- a/sally/tree/11725_트리의 부모 찾기.cpp
+++ b/sally/tree/11725_트리의 부모 찾기.cpp
@@ -1,0 +1,59 @@
+/*
+# Tree
+# Problem: 11725
+# Memory: 9396KB
+# Time: 72ms
+*/
+#include <iostream>
+#include <string.h>
+#include <vector>
+#include <queue>
+#include <stack>
+#include <string>
+#include <algorithm>
+#include <cmath>
+#include <deque>
+using namespace std;
+
+int N;
+queue<int> q;
+vector<int>v [100001];
+bool visit[100001] = {false, };
+vector<pair<int, int>> result;
+
+
+int main(void) {
+    cin.tie(NULL);
+    ios::sync_with_stdio(false);
+
+    cin >> N;
+    for(int i = 0; i < (N-1); i++){
+        int a, b;
+        cin >> a >> b;
+        v[a].push_back(b);
+        v[b].push_back(a);
+    }
+
+    visit[1] = true;
+    q.push(1);
+
+    while(!q.empty()){
+        int q_size = q.size();
+        for(int t = 0; t < q_size; t++){
+            int cur = q.front();
+            q.pop();
+            for(auto i: v[cur]){
+                if(visit[i] == false){
+                    visit[i] = true;
+                    q.push(i);
+                    result.push_back({i, cur});
+                }
+            }
+        }
+    }
+
+    sort(result.begin(), result.end());
+    for(auto i: result) cout << i.second << '\n';
+
+    return 0;
+}

--- a/sally/tree/9934_완전 이진 트리.cpp
+++ b/sally/tree/9934_완전 이진 트리.cpp
@@ -1,0 +1,74 @@
+/*
+# Tree
+# Problem: 9934
+# Memory: 2208KB
+# Time: 0ms
+*/
+#include <iostream>
+#include <string.h>
+#include <vector>
+#include <queue>
+#include <stack>
+#include <string>
+#include <algorithm>
+#include <cmath>
+#include <deque>
+using namespace std;
+
+int K, a, total_len;
+queue<pair<int, int>> q;
+vector<int> v;
+
+
+int main(void) {
+    cin.tie(NULL);
+    ios::sync_with_stdio(false);
+
+    cin >> K;
+    v.push_back(0);
+    int N = pow(2, K) -1;
+    for(int i = 0; i < N; i++){
+        cin >> a;
+        v.push_back(a);
+    }
+    total_len = v.size();
+
+    int start_ = (pow(2, K-1));
+    int step_ = start_;
+    q.push({start_, step_});
+    K--;
+    cout << v[start_] << '\n';
+    v[start_] = 0;
+
+    while(K--){
+        int q_size = q.size();
+        for(int t = 0; t < q_size; t++){
+            int cur = q.front().first;
+            int lr = q.front().second;
+            q.pop();
+
+            int target1 = cur - (lr / 2);
+            int target2 = cur + (lr / 2);
+            if(1 <= target1 && target1 < total_len){
+                if(v[target1]!=0){
+                    q.push({target1, lr / 2});
+                    cout << v[target1] << ' ';
+                    v[target1] = 0;
+                }
+            }
+
+            if(1 <= target2 && target2 < total_len){
+                if(v[target2]!=0){
+                    q.push({target2, lr / 2});
+                    cout << v[target2] << ' ';
+                    v[target2] = 0;
+                }
+            }
+
+        }
+        cout << '\n';
+    }
+
+
+    return 0;
+}


### PR DESCRIPTION
### 📌 푼 문제들

- [9934_완전 이진 트리](https://www.acmicpc.net/problem/9934)
- [11725_트리의 부모 찾기](https://www.acmicpc.net/problem/11725)

---

### 📝 간단한 풀이 과정

#### 9934_완전 이진 트리

- 조건을 찾음
- queue를 반복하는데, depth를 기준으로 `\n`를 출력하도록 함
  - 큐 사이즈 만큼 돌고나면 줄바꿈 출력
- 현재 위치와 남은 길이를 pair 형으로 queue에 담음
- 현재 위치에서 남은 길이를 1/2 하여 뺀 것을 큐에 먼저 담고, 더한것을 다음에 담음(visit 하지 않았다면)
- 큐에 담을때, 해당 위치에 있는 문자를 출력하고, 그 자리를 0으로 만들어, 방문했다는 것을 표시

#### 11725_트리의 부모 찾기

- 노드 수 보다 간선 수가 현저히 작으므로, 간선을 인접리스트로 표현
- 루트(1)을 시작으로, 연결된 노트를 visit 표시하고, queue에 넣음
- queue를 뽑아서 위의 과정을 반복(연결된 노트를 visit 표시하고, queue에 넣음)

---

