### PR TITLE
[펭귄] 2021.06.11

### DIFF
--- a/coodingpenguin/README.md
+++ b/coodingpenguin/README.md
@@ -2,6 +2,7 @@
 
 - [그래프 탐색](#그래프-탐색)
 - [문자열](#문자열)
+- [트리](#트리)
 
 ---
 
@@ -53,3 +54,16 @@
 | 6/09 | <a href="https://www.acmicpc.net/problem/17413" target="_blank">17413</a> |         <a href="https://www.acmicpc.net/problem/17413" target="_blank">단어 뒤집기 2</a>         | <img height="25px" width="25px" src="https://static.solved.ac/tier_small/8.svg"/>  |      |                                                             |
 | 6/09 | <a href="https://www.acmicpc.net/problem/17609" target="_blank">17609</a> |             <a href="https://www.acmicpc.net/problem/17609" target="_blank">회문</a>              | <img height="25px" width="25px" src="https://static.solved.ac/tier_small/10.svg"/> |      |                                                             |
 | 6/10 | <a href="https://www.acmicpc.net/problem/20437" target="_blank">20437</a> |         <a href="https://www.acmicpc.net/problem/20437" target="_blank">문자열 게임 2</a>         | <img height="25px" width="25px" src="https://static.solved.ac/tier_small/11.svg"/> |  ✅  | 연속 문자열의 길이를 구하는 것이 무엇인지를 파악하는 문제   |
+
+### 트리
+
+| 날짜 |                                   번호                                    |                                      문제 이름                                       |                                       난이도                                       | 체크 | 한줄평                                     |
+| :--: | :-----------------------------------------------------------------------: | :----------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------: | :--: | :----------------------------------------- |
+| 6/11 |  <a href="https://www.acmicpc.net/problem/9934" target="_blank">9934</a>  |  <a href="https://www.acmicpc.net/problem/9934" target="_blank">완전 이진 트리</a>   | <img height="25px" width="25px" src="https://static.solved.ac/tier_small/9.svg"/>  |  ✅  | 중위순회(inorder traversal)를 아나요?      |
+| 6/11 | <a href="https://www.acmicpc.net/problem/11725" target="_blank">11725</a> | <a href="https://www.acmicpc.net/problem/11725" target="_blank">트리의 부모 찾기</a> | <img height="25px" width="25px" src="https://static.solved.ac/tier_small/9.svg"/>  |  ✅  | BFS문제인데 전에 풀었던 것 같다. 중복인가? |
+| 6/14 |  <a href="https://www.acmicpc.net/problem/1991" target="_blank">1991</a>  |     <a href="https://www.acmicpc.net/problem/1991" target="_blank">트리 순회</a>     | <img height="25px" width="25px" src="https://static.solved.ac/tier_small/10.svg"/> |      |                                            |
+| 6/14 |  <a href="https://www.acmicpc.net/problem/5639" target="_blank">5639</a>  |  <a href="https://www.acmicpc.net/problem/5639" target="_blank">이진 검색 트리</a>   | <img height="25px" width="25px" src="https://static.solved.ac/tier_small/10.svg"/> |      |                                            |
+| 6/15 |  <a href="https://www.acmicpc.net/problem/1068" target="_blank">1068</a>  |       <a href="https://www.acmicpc.net/problem/1068" target="_blank">트리</a>        | <img height="25px" width="25px" src="https://static.solved.ac/tier_small/11.svg"/> |      |                                            |
+| 6/16 |  <a href="https://www.acmicpc.net/problem/6416" target="_blank">6416</a>  |     <a href="https://www.acmicpc.net/problem/6416" target="_blank">트리인가?</a>     | <img height="25px" width="25px" src="https://static.solved.ac/tier_small/11.svg"/> |      |                                            |
+| 6/17 | <a href="https://www.acmicpc.net/problem/14675" target="_blank">14675</a> | <a href="https://www.acmicpc.net/problem/14675" target="_blank">단절점과 단절선</a>  | <img height="25px" width="25px" src="https://static.solved.ac/tier_small/11.svg"/> |      |                                            |
+| 6/18 | <a href="https://www.acmicpc.net/problem/17073" target="_blank">17073</a> |  <a href="https://www.acmicpc.net/problem/17073" target="_blank">나무 위의 빗물</a>  | <img height="25px" width="25px" src="https://static.solved.ac/tier_small/11.svg"/> |      |                                            |

--- a/coodingpenguin/tree/11725_트리의부모찾기.py
+++ b/coodingpenguin/tree/11725_트리의부모찾기.py
@@ -1,0 +1,37 @@
+# 문제: [BOJ 11725] 트리의 부모 찾기
+# 유형: BFS
+# 메모리/시간: 56808kb / 404ms
+
+import sys
+from collections import defaultdict, deque
+
+input = sys.stdin.readline
+
+
+def bfs(start):
+    queue = deque([start])
+    while queue:
+        v = queue.popleft()
+        for i in graph[v]:
+            # 부모 테이블이 갱신되지 않았다면
+            if parent[i] == i:
+                parent[i] = v  # 갱신
+                queue.append(i)  # 큐에 삽입
+
+
+# 입력
+N = int(input())  # 노드 수
+graph = defaultdict(list)  # 간선 정보
+for _ in range(N - 1):
+    x, y = map(int, input().split())
+    graph[x].append(y)
+    graph[y].append(x)
+
+parent = [i for i in range(N + 1)]  # 부모 테이블
+
+# 너비 우선 탐색
+bfs(1)
+
+# 출력
+for p in parent[2:]:
+    print(p)

--- a/coodingpenguin/tree/9934_완전이진트리.py
+++ b/coodingpenguin/tree/9934_완전이진트리.py
@@ -1,0 +1,24 @@
+# 문제: [BOJ 9934] 완전 이진 트리
+# 유형: 트리
+# 메모리/시간: 32048kb / 88ms
+
+import sys
+from collections import defaultdict
+
+input = sys.stdin.readline
+
+# 입력
+K = int(input())  # 트리 레벨
+paths = list(map(int, input().split()))  # 방문 순서
+
+levels = [K]  # 방문 순서별 트리 레벨
+for i in range(K - 1, 0, -1):
+    levels = levels + [i] + levels
+
+tree = defaultdict(list)  # 레벨 별 노드
+for pos, level in enumerate(levels):
+    tree[level].append(paths[pos])
+
+# 출력
+for _, nodes in sorted(tree.items()):
+    print(*nodes)


### PR DESCRIPTION
### 📌 푼 문제들

- [완전 이진 트리](https://www.acmicpc.net/problem/9934)
- [트리의 부모 찾기](https://www.acmicpc.net/problem/11725)

---

### 📝 간단한 풀이 과정

#### 9934_완전 이진 트리

- 방문 순서별 트리 레벨을 계산하는 리스트 `level`을 생성한다. 예를 들면, 트리의 최대 깊이는 2이고 방문 순서가 [2, 1, 3]이라면, 각 위치에 해당하는 노드의 트리 레벨은 [2, 1, 2]이다.
- `level`을 순회하면서 defaultdict를 사용하여 레벨 별 노드 리스트를 생성하여 저장한다.
- `tree`를 레벨을 기준으로 정렬하고 출력한다.

#### 11725_트리의 부모 찾기

> 그래프 탐색 유형에 동일한 문제가 있었네요. 근데 거의 똑같이 풀고 visited 처리하는 부분만 달랐습니다.

- 간선 정보를 입력 받아 연결리스트 형태로 `graph`에 저장한다.
- 노드 수+1만큼의 부모 테이블 `parent`를 생성하고 자기 자신으로 초기화시킨다.
- 시작 노드를 1로 하여 너비우선탐색을 진행한다.
     - 이 때, 방문 여부를 체크하는 것을 만들지 않고 자신의 부모가 자신인 경우 갱신하지 않은 것 즉, 방문을 하지 않은 것이므로 이를 이용하여 방문 여부를 체크한다.
- 2번 노드부터 자신의 부모를 출력한다. 

---