### PR TITLE
[감자] 2021.06.23

### DIFF
--- a/dkswndms4782/dynamic_programming_1/17626_FourSquares.cpp
+++ b/dkswndms4782/dynamic_programming_1/17626_FourSquares.cpp
@@ -1,0 +1,25 @@
+#include <iostream>
+#include <cmath>
+#include <algorithm>
+using namespace std;
+
+int main() {
+	ios_base::sync_with_stdio(false);
+	cin.tie(NULL);
+	int arr[50001] = { 0, };
+	int n; cin >> n;
+	for (int i = 1; i < 4; i++)
+		arr[i] = i;
+	for (int i = 4; i <= n; i++)
+		arr[i] = 5;
+
+	for (int i = 2; i*i <= n; i++) {
+		arr[i*i] = 1;
+		for (int j = i * i + 1; j < pow(i + 1, 2); j++) {
+			for (int k = i; k > 1; k--) {
+				arr[j] = min(arr[j], arr[k * k] + arr[j - k * k]);
+			}
+		}
+	}
+	cout << arr[n];
+}

--- a/dkswndms4782/dynamic_programming_1/9655_돌게임.cpp
+++ b/dkswndms4782/dynamic_programming_1/9655_돌게임.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+using namespace std;
+
+int main() {
+	int n; cin >> n;
+	cout << (n % 2 ? "SK" : "CY");
+}


### PR DESCRIPTION
### 📌 푼 문제들

- [돌게임](https://www.acmicpc.net/problem/9655)
- [FourSquares](https://www.acmicpc.net/problem/17626)

---

### 📝 간단한 풀이 과정

#### 돌게임

- 블로그를 참고하였습니다🥺
- 수가 홀수일때는 상근이가, 짝수일때는 창영이가 이기는 구조입니다.
- 홀수면 SK출력, 짝수면 CY출력

#### FourSquares

- arr[50001] =  {0,}; 선언 후 idx는 3이하는 idx만큼의 값 할당. 
- 나머지는 5로 초기화
- dp로 현재 값보다 작은 제곱수와 현재 idx-제곱수의 합 중 가장 작은 값 arr에 할당. 

---

