### PR TITLE
[튜브] 2021.06.25

### DIFF
--- a/peacecheejecake/README.md
+++ b/peacecheejecake/README.md
@@ -17,10 +17,12 @@
 |날짜|번호|제목|문제|
 |---|---|---|---|
 |6/21|10870|피보나치 수 5|[link](https://www.acmicpc.net/problem/10870)|
-|6/21|2839|설탕 배달[link](https://www.acmicpc.net/problem/2839)|
-|6/22|2748|피보나치 수 2[link](https://www.acmicpc.net/problem/2748)|
-|6/22|1010|다리 놓기[link](https://www.acmicpc.net/problem/1010)|
-|6/23|9655|돌 게임[link](https://www.acmicpc.net/problem/9655)|
-|6/23|1010|Four Squares[link](https://www.acmicpc.net/problem/17626)|
-|6/24|1463|1로 만들기[link](https://www.acmicpc.net/problem/1463)|
-|6/24|9095|1, 2, 3 더하기[link](https://www.acmicpc.net/problem/9095)|
+|6/21|2839|설탕 배달|[link](https://www.acmicpc.net/problem/2839)|
+|6/22|2748|피보나치 수 2|[link](https://www.acmicpc.net/problem/2748)|
+|6/22|1010|다리 놓기|[link](https://www.acmicpc.net/problem/1010)|
+|6/23|9655|돌 게임|[link](https://www.acmicpc.net/problem/9655)|
+|6/23|1010|Four Squares|[link](https://www.acmicpc.net/problem/17626)|
+|6/24|1463|1로 만들기|[link](https://www.acmicpc.net/problem/1463)|
+|6/24|9095|1, 2, 3 더하기|[link](https://www.acmicpc.net/problem/9095)|
+|6/25|11726|2xn 타일링|[link](https://www.acmicpc.net/problem/11726)|
+|6/25|2579|계단 오르기|[link](https://www.acmicpc.net/problem/2579)|

--- a/peacecheejecake/dynamic_programming_1/11726_2xn타일링.py
+++ b/peacecheejecake/dynamic_programming_1/11726_2xn타일링.py
@@ -1,0 +1,11 @@
+# https://www.acmicpc.net/problem/11726
+# 2xn 타일링
+# 29200 KB / 68 ms
+
+n = int(input())
+table = [0, 1, 2] + [0] * (n - 2)
+
+for i in range(3, n + 1):
+    table[i] = (table[i - 1] + table[i - 2]) % 10007
+
+print(table[n])

--- a/peacecheejecake/dynamic_programming_1/2579_계단오르기.py
+++ b/peacecheejecake/dynamic_programming_1/2579_계단오르기.py
@@ -1,0 +1,33 @@
+# https://www.acmicpc.net/problem/2579
+# 계단 오르기
+# 29200 KB / 64 ms
+
+import sys
+
+
+def input():
+    return sys.stdin.readline().strip()
+
+
+num_steps = int(input())
+steps = []
+for _ in range(num_steps):
+    steps.append(int(input()))
+
+if num_steps < 3:
+    max_score = sum(steps)
+else:
+    best_scores = [
+        steps[0], # 1층: 무조건 밟을 때 최대
+        sum(steps[:2]), # 2층: 전부 밟을 때 최대
+        max(steps[:2]) + steps[2], # 3층: 1, 2층 중 더 큰 점수를 밟을 때 최대
+    ]
+    for i in range(3, num_steps):
+        best_score = max(
+            best_scores[i - 2], # i - 1번째 계단 밟지 않았을 때
+            best_scores[i - 3] + steps[i - 1], # i - 1번째 계단 밟았을 때
+        ) + steps[i]
+        best_scores.append(best_score)
+    max_score = best_scores[-1]
+
+print(max_score)


### PR DESCRIPTION
### 📌 푼 문제들

- [11726_2xn 타일링](https://www.acmicpc.net/problem/11726)
- [2579_계단 오르기](https://www.acmicpc.net/problem/2579)

---

### 📝 간단한 풀이 과정

#### 11726_2xn 타일링

- n이 1, 2일 때의 경우의 수는 각각 1, 2이다.
- i번째 경우의 수는 i - 1번째 및 i - 2번째 경우의 수 합이다.
- `(a + b) % c == (a % c + b % c) % c`라는 점을 이용해 `table`에는 10007로 나눈 나머지를 담는다.
- `table`의 마지막(n번째) 원소를 출력한다.

#### 2579_계단 오르기

- 전체 계단 수가 3보다 작으면, 모든 점수를 더해서 출력한다.
- 그렇지 않은 경우, 다음과 같이 구한다.
  - 1~3층에서 얻을 수 있는 최대 점수를 `best_scores`에 담는다.
  - 4층부터는 다음의 두 경우 중 최댓값을 이전 계단까지의 최대 점수로 한다.
    1. 직전 계단을 밟은 경우 : 세 번째 전 계단까지의 최대 점수에 직전 계단의 점수
    2. 직전 계단을 밟지 않은 경우 : 두 번째 전 계단까지의 최대 점수
  - `이전 계단까지의 최대 점수 + 현재 층의 점수`를 `best_scores`에 담는다.
  - `best_scores`의 마지막 원소를 출력한다.
