### PR TITLE
[감자] 2021.06.25

### DIFF
--- a/dkswndms4782/dynamic_programming_1/11726_2xn타일링.cpp
+++ b/dkswndms4782/dynamic_programming_1/11726_2xn타일링.cpp
@@ -1,0 +1,19 @@
+#include <iostream>
+using namespace std;
+
+int arr[1001];
+int dp(int n) {
+	if (arr[n] > 0) return arr[n];
+	arr[n] = dp(n - 1) + dp(n - 2);
+	arr[n] %= 10007;
+	return arr[n];
+}
+
+int main() {
+	ios_base::sync_with_stdio(false);
+	cin.tie(NULL);
+	int n; cin >> n;
+	for (int i = 1; i < 3; i++)
+		arr[i] = i;
+	cout << dp(n);
+}

--- a/dkswndms4782/dynamic_programming_1/2579_계단오르기.cpp
+++ b/dkswndms4782/dynamic_programming_1/2579_계단오르기.cpp
@@ -1,0 +1,22 @@
+#include <iostream>
+#include <algorithm>
+using namespace std;
+
+int stairs[301] = { 0, };
+//현재 한칸이면 [n][1], 현재 두칸째이면 [n][2]
+int score[301][3] = { (0,0,0), };
+
+int main() {
+	ios_base::sync_with_stdio(false);
+	cin.tie(NULL);
+	int N; cin >> N;
+	for (int i = 1; i <= N; i++)
+		cin >> stairs[i];
+	score[1][1] = stairs[1];
+	score[2][1] = stairs[2];  score[2][2] = score[1][1] + stairs[2];
+	for (int i = 3; i <= N; i++) {
+		score[i][2] = score[i - 1][1] + stairs[i];
+		score[i][1] = max(score[i - 2][1], score[i - 2][2]) + stairs[i];
+	}
+	cout << max(score[N][1], score[N][2]);
+}

--- a/dkswndms4782/dynamic_programming_1/2579_계단오르기.cpp
+++ b/dkswndms4782/dynamic_programming_1/2579_계단오르기.cpp
@@ -2,7 +2,6 @@
 #include <algorithm>
 using namespace std;
 
-int stairs[301] = { 0, };
 //현재 한칸이면 [n][1], 현재 두칸째이면 [n][2]
 int score[301][3] = { (0,0,0), };
 
@@ -11,12 +10,12 @@ int main() {
 	cin.tie(NULL);
 	int N; cin >> N;
 	for (int i = 1; i <= N; i++)
-		cin >> stairs[i];
-	score[1][1] = stairs[1];
-	score[2][1] = stairs[2];  score[2][2] = score[1][1] + stairs[2];
+		cin >> score[i][0];
+	score[1][1] = score[1][0];
+	score[2][1] = score[2][0];  score[2][2] = score[1][1] + score[2][0];
 	for (int i = 3; i <= N; i++) {
-		score[i][2] = score[i - 1][1] + stairs[i];
-		score[i][1] = max(score[i - 2][1], score[i - 2][2]) + stairs[i];
+		score[i][2] = score[i - 1][1] + score[i][0];
+		score[i][1] = max(score[i - 2][1], score[i - 2][2]) + score[i][0];
 	}
 	cout << max(score[N][1], score[N][2]);
 }


### PR DESCRIPTION
### 📌 푼 문제들

- [2xn 타일링](https://www.acmicpc.net/problem/11726)
- [계단오르기](https://www.acmicpc.net/problem/2579)

---

### 📝 간단한 풀이 과정

#### 2xn 타일링

- 점화식
    - (idx = 1,2) -> arr[idx] = idx
    - (idx > 2) -> arr[n] = arr[n-1] + arr[n-2]
- arr[n-1]은 arr[n]번째에서 맨 뒤에 1x2블록을 붙이는 경우의 수
- arr[n-2]는  arr[n]번째에서 맨 뒤에 2x1블록을 두개 가로로 붙이는 경우의 수

#### 계단오르기

- 점화식
    - (i = 1, 2) -> score[1][1] =score[1][0], score[2][1] =  score[2][0], score[2][2] = score[1][1] + score[2][0]
    - (i > 2) -> score[i][2] = score[i - 1][1] + score[i][0];
		      score[i][1] = max(score[i - 2][1], score[i - 2][2]) + score[i][0];
- 첫번째 idx는 계단의 순서, 두번째 idx는 연속으로 오른 계단의 수
- score[i][0]은 현재 계단의 점수
- 현재 idx가 i라고 할때, score[i][2]는 바로 직전 계단에서 올라오는 경우의 수밖에 없음. 
- 현재 idx가 i라고 할때, score[i][1]은 두칸 밑 계단에서 올라오는 경우의 수인데, 두칸 밑 계단에서 연속으로 1칸, 2칸 오른것은 상관없기때문에 더 큰값에 score[i][0]을 더함

---
