### PR TITLE
[후미] 2021.06.25

### DIFF
--- a/opijae/dynamic_programming_1/11726_2xn타일링.py
+++ b/opijae/dynamic_programming_1/11726_2xn타일링.py
@@ -1,0 +1,8 @@
+import sys
+input = sys.stdin.readline
+
+n= int(input())
+arr=[1,1] # arr[0]은 padding
+for i in range(2,n+1):
+    arr.append(arr[-1]+arr[-2]) # 그 전 값이랑 그 전전 값(가로로 두었을 때) 를 더함
+print(arr[n]%10007)

--- a/opijae/dynamic_programming_1/2579_계단오르기.py
+++ b/opijae/dynamic_programming_1/2579_계단오르기.py
@@ -1,0 +1,14 @@
+import sys
+input = sys.stdin.readline
+n= int(input())
+stairs=[0]
+for _ in range(n):
+    stairs.append(int(input()))
+dp=[0,stairs[1]] # dp에는 i번 까지의 계단을 밟았을때 최대 점수를 기록한 배열이다.
+if n>1:
+    dp.append(stairs[1]+stairs[2])
+for i in range(3,n+1):
+    # OXO , OXOO 경우를 생각하면된다.(X는 안밟음, O는 밟음)
+    # OXO는 그 전 계단을 밟든 안밟든 상관 없기 떄문에 신경안써준다.
+    dp.append(max(dp[i-2]+stairs[i],dp[i-3]+stairs[i-1]+stairs[i])) 
+print(dp[n])


### PR DESCRIPTION
### 📌 푼 문제들

- [2xn타일링](https://www.acmicpc.net/problem/11726)
- [계단오르기](https://www.acmicpc.net/problem/2579)

---

### 📝 간단한 풀이 과정

#### 2xn타일링

- 현재 타일은 이전 타일(세로로 했을때) + 전전 타일(가로로 했을때)의 값을 더해준다.

#### 계단오르기

- 어려웠다,.....
- 계단의 값을 저장하는 `stairs` , 계단의 최대 값을 저장하는 `dp` 배열을 만든다.
- 3개연속으로 밟으면 안되니 현재 밟으려는 칸을 기준으로 전 3칸을 봐 현재 칸까지 올수 있는 경우의 수를 구한다,

---

