### PR TITLE
[튜브] 2021.06.28

### DIFF
--- a/peacecheejecake/README.md
+++ b/peacecheejecake/README.md
@@ -26,3 +26,5 @@
 |6/24|9095|1, 2, 3 더하기|[link](https://www.acmicpc.net/problem/9095)|
 |6/25|11726|2xn 타일링|[link](https://www.acmicpc.net/problem/11726)|
 |6/25|2579|계단 오르기|[link](https://www.acmicpc.net/problem/2579)|
+|6/28|11727|2xn 타일링 2|[link](https://www.acmicpc.net/problem/11727)|
+|6/28|11053|가장 긴 증가하는 부분 수열|[link](https://www.acmicpc.net/problem/11053)|

--- a/peacecheejecake/dynamic_programming_1/11053_가장긴증가하는부분수열.py
+++ b/peacecheejecake/dynamic_programming_1/11053_가장긴증가하는부분수열.py
@@ -1,0 +1,12 @@
+# https://www.acmicpc.net/problem/11053
+# 가장 긴 증가하는 부분 수열
+# 29200 KB / 204 ms
+
+n = int(input())
+arr = [int(x) for x in input().split()]
+table = [1] * n
+for i, a in enumerate(arr):
+    for j in range(i):
+        if arr[i] > arr[j]:
+            table[i] = max(table[i], table[j] + 1)
+print(max(table))

--- a/peacecheejecake/dynamic_programming_1/11727_2xn타일링2.py
+++ b/peacecheejecake/dynamic_programming_1/11727_2xn타일링2.py
@@ -1,0 +1,9 @@
+# https://www.acmicpc.net/problem/11727
+# 2xn 타일링 2
+# 29200 KB / 84 ms
+
+n = int(input())
+table = [1, 1] + [0] * (n - 1)
+for i in range(2, n + 1):
+    table[i] = (2 * table[i - 2] + table[i - 1]) % 10007
+print(table[-1])


### PR DESCRIPTION
### 📌 푼 문제들

- [11727_2xn 타일링 2](https://www.acmicpc.net/problem/11727)
- [11053_가장 긴 증가하는 부분 수열](https://www.acmicpc.net/problem/11053)

---

### 📝 간단한 풀이 과정

#### 11727_2xn 타일링 2

- 가장 끝에 가로 길이가 2인 타일이 들어올 때, 경우의 수가 2가 된다는 점이 `11726_2xn 타일링`과 다르다.
- 따라서, 점화식을 `table[i] = table[i - 1] + 2 * table[i - 2]`와 같이 세울 수 있다.

#### 11053_가장 긴 증가하는 부분 수열

- `table`의 모든 원소를 1로 초기화한다.
- `j < i`이고 `arr[j] < arr[i]`)를 만족하는 j에 대해서, `table[j]` 값의 최댓값을 구하고, 여기에 1을 더하여 `table[i]`를 갱신한다.
- `table`의 최댓값이 `가장 긴 증가하는 부분 수열`의 길이가 된다.

