### PR TITLE
[감자] 2021.06.28

### DIFF
--- a/dkswndms4782/dynamic_programming_1/11053_가장긴증가하는부분수열.cpp
+++ b/dkswndms4782/dynamic_programming_1/11053_가장긴증가하는부분수열.cpp
@@ -1,0 +1,21 @@
+#include <iostream>
+#include <vector>
+using namespace std;
+
+int main() {
+	ios_base::sync_with_stdio(false);
+	cin.tie(NULL);
+	int N; cin >> N;
+	int num[1001];
+	int length[1001] = {0,};
+	for (int i = 0; i < N; i++) cin >> num[i];
+	int max = 0;
+	for (int i = 0; i < N; i++) {
+		for (int j = 0; j < i; j++) {
+			if (num[j] < num[i] && length[j] >= length[i]) length[i] = length[j] + 1;
+		}
+		if (length[i] == 0) length[i] = 1;
+		if (max < length[i]) max = length[i];
+	}
+	cout << max;
+}

--- a/dkswndms4782/dynamic_programming_1/11727_2xn타일링2.cpp
+++ b/dkswndms4782/dynamic_programming_1/11727_2xn타일링2.cpp
@@ -3,10 +3,10 @@ using namespace std;
 
 int arr[1001];
 int dp(int n) {
-    if(n == 1) return 1;
-    if(n == 2) return 3;
+	if (n == 1) return 1;
+	if (n == 2) return 3;
 	if (arr[n] > 0) return arr[n];
-	arr[n] = dp(n - 1) + dp(n - 2) * 2;
+	arr[n] = dp(n - 1) + dp(n - 2)*2;
 	arr[n] %= 10007;
 	return arr[n];
 }

--- a/dkswndms4782/dynamic_programming_1/11727_2xn타일링2.cpp
+++ b/dkswndms4782/dynamic_programming_1/11727_2xn타일링2.cpp
@@ -1,0 +1,19 @@
+#include <iostream>
+using namespace std;
+
+int arr[1001];
+int dp(int n) {
+    if(n == 1) return 1;
+    if(n == 2) return 3;
+	if (arr[n] > 0) return arr[n];
+	arr[n] = dp(n - 1) + dp(n - 2) * 2;
+	arr[n] %= 10007;
+	return arr[n];
+}
+
+int main() {
+	ios_base::sync_with_stdio(false);
+	cin.tie(NULL);
+	int n; cin >> n;
+	cout << dp(n);
+}


### PR DESCRIPTION
### 📌 푼 문제들

- [2xn 타일링2](https://www.acmicpc.net/problem/11727)
- [가장 긴 증가하는 부분 수열](https://www.acmicpc.net/problem/11053)

---

### 📝 간단한 풀이 과정

#### 2xn 타일링2
- 점화식
    - (idx = 1) -> arr[1] = 1
    - (idx = 2) -> arr[2] = 3
    - (idx > 2) -> arr[n] = arr[n-1] + arr[n-2] * 2
- 마지막 두칸이 가로2칸 쌓은 것, 2x2 한칸이 되는 경우 2경우가 있어서 *2를 해주었다. 

#### 가장 긴 증가하는 부분 수열

- 현재 숫자와 이전 숫자들을 비교한 후, 이전 숫자보다 현재 숫자가 크다면, 길이 비교
- 길이 비교를 했을 때 현재 길이보다 이전 숫자의 길이가 크거나 같으면, 현재 길이는 이전숫자 + 1이 된다. 

---

