### PR TITLE
[튜브] 2021.06.29

### DIFF
--- a/peacecheejecake/.gitignore
+++ b/peacecheejecake/.gitignore
@@ -1,0 +1,1 @@
+failures/

--- a/peacecheejecake/README.md
+++ b/peacecheejecake/README.md
@@ -28,3 +28,5 @@
 |6/25|2579|계단 오르기|[link](https://www.acmicpc.net/problem/2579)|
 |6/28|11727|2xn 타일링 2|[link](https://www.acmicpc.net/problem/11727)|
 |6/28|11053|가장 긴 증가하는 부분 수열|[link](https://www.acmicpc.net/problem/11053)|
+|6/29|1912|연속합|[link](https://www.acmicpc.net/problem/1912)|
+|6/29|9465|스티커|[link](https://www.acmicpc.net/problem/9465)|

--- a/peacecheejecake/dynamic_programming_1/1912_연속합.py
+++ b/peacecheejecake/dynamic_programming_1/1912_연속합.py
@@ -1,0 +1,11 @@
+# https://www.acmicpc.net/problem/1912
+# 연속합
+# 37164 KB / 128 ms
+
+
+n = int(input())
+numbers = [int(x) for x in input().split()]
+for i in range(1, n):
+    numbers[i] += max(0, numbers[i - 1])
+
+print(max(numbers))

--- a/peacecheejecake/dynamic_programming_1/9465_스티커.py
+++ b/peacecheejecake/dynamic_programming_1/9465_스티커.py
@@ -1,6 +1,6 @@
 # https://www.acmicpc.net/problem/9465
 # 스티커 (DP)
-# 58984 KB / 1268 ms
+# 58984 KB / 1068 ms
 
 
 import sys
@@ -21,8 +21,8 @@ def get_partial_max(max_table, column):
     prev_prev, prev = max_table[-2:]
     upper, lower = column
 
-    upper += max(max(prev_prev), prev[1]) # 선택 안함 vs 아래 선택
-    lower += max(max(prev_prev), prev[0]) # 선택 안함 vs 위 선택
+    upper += max(prev_prev[1], prev[1]) # 선택 안함 vs 아래 선택
+    lower += max(prev_prev[0], prev[0]) # 선택 안함 vs 위 선택
     return (upper, lower)
 
 

--- a/peacecheejecake/dynamic_programming_1/9465_스티커.py
+++ b/peacecheejecake/dynamic_programming_1/9465_스티커.py
@@ -1,0 +1,46 @@
+# https://www.acmicpc.net/problem/9465
+# 스티커 (DP)
+# 58984 KB / 1268 ms
+
+
+import sys
+
+readline = sys.stdin.readline
+
+
+def get_single_input():
+    n = int(readline())
+    stickers = []
+    for _ in range(2):
+        stickers.append([int(x) for x in readline().split()])
+    stickers = list(zip(*stickers))
+    return n, stickers
+
+
+def get_partial_max(max_table, column):
+    prev_prev, prev = max_table[-2:]
+    upper, lower = column
+
+    upper += max(max(prev_prev), prev[1]) # 선택 안함 vs 아래 선택
+    lower += max(max(prev_prev), prev[0]) # 선택 안함 vs 위 선택
+    return (upper, lower)
+
+
+T = int(readline())
+
+for _ in range(T):
+    n, stickers = get_single_input()    
+
+    max_0 = stickers[0]
+    max_1 = (
+        stickers[0][1] + stickers[1][0], 
+        stickers[0][0] + stickers[1][1],
+    )
+    max_table = [max_0, max_1]
+    for i in range(2, n):
+        max_table.append(
+            get_partial_max(max_table, stickers[i])
+        )
+    max_score = max(max_table[-1])
+    
+    print(max_score)


### PR DESCRIPTION
### 📌 푼 문제들

- [1912_연속합](https://www.acmicpc.net/problem/1912)
- [9465_스티커](https://www.acmicpc.net/problem/9465)

---

### 📝 간단한 풀이 과정

#### 1912_연속합

- 주어진 수열을 `numbers`에 담는다.
- 수열이 i번째 원소까지만 있다고 생각할 때 최대 연속합을 구한다.
- 직전 최대 연속합이 음수이면 연속합을 이어가고, 아니면 연속합을 새로 시작한다.
- 어느 경우든 `numbers[i]`가 포함되므로, `numbers`를 앞에서부터 갱신하면 된다.

#### 9465_스티커

- 각각의 점수를 2xn 리스트 `stickers`에 담는다.
- `max_table[i]`은 i번째 열까지의 최댓값이다. 마지막 스티커 위치가 다음 열 계산에 영향을 주므로, (`윗쪽 스티커를 선택했을 때 최댓값`, `아랫쪽 스티커를 선택했을 때의 최댓값`)을 담은 tuple로 저장한다.
- `max_table[0]`은 `stickers[0]`과 같다.
- `max_table[1]`은 `stickers[1]`과 `stickers[0]`의 원소를 교차로 더한 것과 같다.
- i이 2 이상일 때, `max_table[i]`은 다음과 같은 규칙으로 구한다.
  - i번째 행에서 위쪽 스티커를 고른다면(`upper`), 두 가지 경우의 수가 가능하다.
    1. i-1열의 아래쪽 스티커를 선택하기
    2. i-2열의 위쪽 스티커를 선택하기 위해 i-1열에서는 아무것도 선택하지 않기
  - 둘 중 최댓값이 `max_table[i]`의 위쪽 원소가 된다.
  - 같은 방법으로 `max_table[i]`의 아래쪽 원소를 구한다.
- 어떤 경우에도 마지막 열의 스티커를 건너뛰고 최댓값이 될 수 없다. 따라서 `max_table[-1]`의 두 값 중 더 큰 것을 출력한다.