### PR TITLE
[감자] 2021.06.30

### DIFF
--- a/dkswndms4782/dynamic_programming_1/11055_가장큰증가부분수열.cpp
+++ b/dkswndms4782/dynamic_programming_1/11055_가장큰증가부분수열.cpp
@@ -1,0 +1,21 @@
+#include <iostream>
+#include <vector>
+using namespace std;
+
+int main() {
+	ios_base::sync_with_stdio(false);
+	cin.tie(NULL);
+	int N; cin >> N;
+	int num[1001];
+	int length[1001] = {0,};
+	for (int i = 0; i < N; i++) cin >> num[i];
+	int max = 0;
+	for (int i = 0; i < N; i++) {
+		for (int j = 0; j < i; j++) {
+			if (num[j] < num[i] && length[i] < (length[j] + num[i])) length[i] = length[j] + num[i];
+		}
+		if (length[i] == 0) length[i] = num[i];
+		if (max < length[i]) max = length[i];
+	}
+	cout << max;
+}

--- a/dkswndms4782/dynamic_programming_1/1890_점프.cpp
+++ b/dkswndms4782/dynamic_programming_1/1890_점프.cpp
@@ -1,0 +1,22 @@
+#include <iostream>
+using namespace std;
+
+int main(){
+    ios_base::sync_with_stdio(false);
+    cin.tie(NULL);
+    int N;cin >> N;
+    int arr[101][101];
+    for(int i = 0;i< N;i++){
+        for(int j = 0;j<N;j++)
+            cin >> arr[i][j];
+    }
+    long long int dp[101][101] = {1,};
+    for(int i = 0;i<N;i++){
+        for(int j = 0;j<N;j++){
+            if(dp[i][j] == 0 || (i == (N-1) && j == (N-1))) continue;
+            if((j + arr[i][j]) < N) dp[i][j + arr[i][j]] += dp[i][j];
+            if((i + arr[i][j]) < N) dp[i + arr[i][j]][j] += dp[i][j];
+        }
+    }
+    cout << dp[N-1][N-1];
+}


### PR DESCRIPTION
### 📌 푼 문제들

- [가장 큰 증가 부분 수열](https://www.acmicpc.net/problem/11055)
- [점프](https://www.acmicpc.net/problem/1890)

---

### 📝 간단한 풀이 과정

#### 가장 큰 증가 부분 수열
- 현재 숫자가 이전 숫자보다 크고 현재 합이 이전 합과 현재 값의 합보다 작은 경우 현재 합에 이전 합 + 현재 값을 할당
- 현재 합이 0일경우 현재 값 할당

#### 점프

- 이중포문사용
- dp[0][0] = 1
- dp[i][j]가 0일경우와 마지막 도착지의 경우 continue
- i + 현재값 혹은 j + 현재값이 N보다 작을 경우, 이동해준 좌표에 dp[i][j]더해주기
- 2^63-1만큼의 개수가 나올 수 있었으므로 int형에 담아줄 수 없음. long long int로 배열 자료형 지정

---

