### PR TITLE
[후미] 2021.07.02

### DIFF
--- a/opijae/dynamic_programming_1/1106_호텔.py
+++ b/opijae/dynamic_programming_1/1106_호텔.py
@@ -2,7 +2,7 @@ import sys
 input = sys.stdin.readline
 target_num , n = map(int, input().split())
 
-dp=[0]*1000000 # 최소 비용의 dp. dp[1]은 비용 1일때 최대 손님 수
+dp=[0]*1000000 # 최소 비용의 dp. dp[1]은 비용 1일때 최대 손님 수    
 arr=[]
 for _ in range(n):
     arr.append(list(map(int, input().split())))

--- a/opijae/dynamic_programming_1/15486_퇴사2.py
+++ b/opijae/dynamic_programming_1/15486_퇴사2.py
@@ -1,0 +1,19 @@
+import sys
+input = sys.stdin.readline
+def solve():
+    n= int(input())
+    arr=[0]*(n+1)
+    _max=0
+    for i in range(n):
+        t,p=map(int, input().split())
+        _max=max(_max,arr[i])
+        if t+i>n:
+            continue
+        if arr[i+t]<p+_max:
+            arr[i+t]=p+_max
+#     arr[i+t]=max(arr[i+t],_max+p)
+    _max=max(_max,arr[i+1])
+    print(_max)
+    # print(max(arr))
+
+solve()

--- a/opijae/dynamic_programming_1/2156_포도주시식.py
+++ b/opijae/dynamic_programming_1/2156_포도주시식.py
@@ -1,0 +1,13 @@
+import sys
+input = sys.stdin.readline
+n= int(input())
+wine=[0]
+for _ in range(n):
+    wine.append(int(input()))
+dp=[0,wine[1]] # dp에는 i번 까지의 포도주를 마셨을때 최대 양를 기록한 배열이다.
+if n>1:
+    dp.append(wine[1]+wine[2])
+for i in range(3,n+1):
+    # OXO , OXOO, OOX 경우를 생각하면된다.(X는 안마심, O는 마심)
+    dp.append(max(dp[i-2]+wine[i],dp[i-3]+wine[i-1]+wine[i],dp[i-1]))
+print(dp[n])


### PR DESCRIPTION
### 📌 푼 문제들

- [퇴사2](https://www.acmicpc.net/problem/15486)
- [포도주시식](https://www.acmicpc.net/problem/2156)

---

### 📝 간단한 풀이 과정

#### 퇴사2

- 입력이 `시간, 급여` 로 주어지니 `arr[i+t]=max(arr[i+t],_max+p)` 식으로 오늘 상담을 했다면 끝나는 날 기준 최대 금액을 구하는 식으로 한다.
- `_max`는 상담을 꼭 매일 받아야 최대값이 나온다는 보장이 없으니 현재 날짜 기준 최대 금액을 가지고 있다 다음 상담 날짜를 잡을 때 더해줘야된다.

#### 포도주시식

- 앞서 풀었던 [계단오르기](https://github.com/boostcamp-ai-tech-4/coding-test-study/pull/131) 랑 비슷한 문제인다.
- 다른점은 계단오르기는 `꼭 끝점을 밟아야되는데` 이건 아니다.
   - 이 문제에서는 OOX 처럼 마지막껄 안마셔도 된다는 뜻이다.

---

### 🙌 궁금한 점

- 다른 분 풀이를 보면서 얻은  `퇴사2` 700ms 줄인 꿀팁????
1. max vs if
`max` 를 안쓰고 손수 `if`문 쓰니 300ms가 주는 것을 확인 할 수 있다.

```python
arr[i+t]=max(arr[i+t],_max+p)  # 2556 ms
```
```python
if arr[i+t]<p+_max:
    arr[i+t]=p+_max # 2292 ms
```
2. 함수 사용
```python  
n= int(input())  # 2292ms
arr=[0]*(n+1)
_max=0
......
중략
......
````

```python
def solve():  # 1868ms
    n= int(input())
    arr=[0]*(n+1)
    _max=0
    .......
    중략
    .......
solve()
```
- 제가 알기로는 python에서 함수를 호출 할떄 오버헤드가 크다고 알고 있는데 함수를 쓰니 시간이 400ms 가 주는데 왜 그럴까요?

---
