### PR TITLE
[감자] 2021.07.05

### DIFF
--- a/dkswndms4782/dynamic_programming_1/10844_쉬운계단수.cpp
+++ b/dkswndms4782/dynamic_programming_1/10844_쉬운계단수.cpp
@@ -1,0 +1,28 @@
+#include <iostream>
+using namespace std;
+
+#define MAX 1000000000
+long long int dp[102][10] = {0,};
+
+
+int main(){
+    int N; cin >> N;
+    for(int i = 1;i<=9;i++)
+        dp[1][i] = 1;
+    for(int i = 2;i<=N;i++){
+        for(int j = 0;j<10;j++){
+            if(j == 0)
+                dp[i][j] = dp[i-1][1] % MAX;
+            else if(j == 9)
+                dp[i][j] = dp[i-1][8] % MAX;
+            else
+                dp[i][j] = (dp[i-1][j-1] + dp[i-1][j+1])% MAX;
+        }
+    }
+    long long int result = 0;
+    for(int i = 0;i<10;i++){
+        result += dp[N][i];
+        result %= MAX;
+    }
+    cout << result;
+}

--- a/dkswndms4782/dynamic_programming_1/2293_동전1.cpp
+++ b/dkswndms4782/dynamic_programming_1/2293_동전1.cpp
@@ -1,0 +1,17 @@
+#include<iostream>
+using namespace std;
+
+int coin[101];
+int dp[10002];
+
+int main(){
+    int N,K; cin >> N >> K;
+    for(int i = 1;i<= N;i++) cin >> coin[i];
+    dp[0] = 1;
+    for(int i = 1;i<=N;i++){
+        for(int j = coin[i];j <= K;j++){
+            dp[j] += dp[j-coin[i]];
+        }
+    }
+    cout << dp[K];
+}


### PR DESCRIPTION
### 📌 푼 문제들

- [쉬운계단수](https://www.acmicpc.net/problem/10844)
- [동전1](https://www.acmicpc.net/problem/2293)

---

### 📝 간단한 풀이 과정

#### 쉬운 계단 수

- 한자리수는 1~9
- 두번째부터는 0 사용 가능
    - n번째 자릿수가 0이면 1가지 경우의 수(1인경우)이므로 dp[i-1][1]
    - n번째 자릿수가 9이면 1가지 경우의 수(8인경우)이므로 dp[i-1][8]
    - n번째 자릿수가 나머지 숫자면 dp[i-1][j-1] + dp[i-1][j+1]
#### 동전 1

- 동전의 가치와 같은 값은 1가지 경우의 수가 무조건 추가
- 이때 dp[j] = dp[j] + dp[j - coin[i]]가 되어야함
- 각 coin의 값부터 K값까지 dp의 경우의 수 더해줌

---

