### PR TITLE
[샐리] 2021.07.13

### DIFF
--- a/sally/README.md
+++ b/sally/README.md
@@ -110,8 +110,8 @@
 - [X] **11403_경로 찾기** / [문제](https://www.acmicpc.net/problem/11403) / [풀이]()
 - [X] **2224_명제 증명** / [문제](https://www.acmicpc.net/problem/2224) / [풀이]()
 - [X] **11265_끝나지 않는 파티** / [문제](https://www.acmicpc.net/problem/11265) / [풀이]()
-- [ ] 1753_최단경로 / [문제](https://www.acmicpc.net/problem/1753) / [풀이]()
-- [ ] 13549_숨바꼭질 3 / [문제](https://www.acmicpc.net/problem/13549) / [풀이]()
+- [X] **1753_최단경로** / [문제](https://www.acmicpc.net/problem/1753) / [풀이]()
+- [X] **13549_숨바꼭질 3** / [문제](https://www.acmicpc.net/problem/13549) / [풀이]()
 
 ---
 

--- a/sally/shortest_path/13549_숨바꼭질 3(1).cpp
+++ b/sally/shortest_path/13549_숨바꼭질 3(1).cpp
@@ -1,0 +1,72 @@
+/*
+# DP
+# Problem: 13549
+# Memory: 2632KB
+# Time: 4ms
+*/
+#include <iostream>
+#include <cmath>
+#include <vector>
+#include <queue>
+using namespace std;
+
+#define MAX 100001
+#define my_pair pair<int, int>
+
+int N, K;
+int result = 0;
+priority_queue<my_pair, vector<my_pair>, greater<my_pair>> q;
+bool visit[MAX] = {false,};
+
+int main(void) {
+    cin.tie(NULL);
+    ios::sync_with_stdio(false);
+
+    // input
+    cin >> N >> K;
+
+    // init
+    visit[N] = true; 
+    q.push({0, N}); // val, ind
+
+    // dijkstra
+    while(!q.empty()){
+        int cur = q.top().second;
+        int cur_day = q.top().first;
+        q.pop();
+
+        // end condition
+        if(cur == K) {
+            result = cur_day;
+            break;
+        }
+
+        // important !!! sequence(*2 -> +1 -> -1)
+        int target = cur * 2;
+        if (0 <= target && target < MAX)
+            if (!visit[target])
+            {
+                visit[target] = true;
+                q.push({cur_day, target});
+            }
+        target = cur + 1;
+        if (0 <= target && target < MAX)
+            if(!visit[target]) {
+                visit[target] = true;
+                q.push({cur_day + 1, target});
+            }
+
+        target = cur - 1;
+        if (0 <= target && target < MAX)
+            if (!visit[target]){
+                visit[target] = true;
+                q.push({cur_day + 1, target});
+            }
+
+        
+    }
+
+    cout << result;
+
+    return 0;
+}

--- a/sally/shortest_path/1753_최단경로.cpp
+++ b/sally/shortest_path/1753_최단경로.cpp
@@ -1,0 +1,66 @@
+/*
+# DP
+# Problem: 1753
+# Memory: 9184KB
+# Time: 100ms
+*/
+#include <iostream>
+#include <cmath>
+#include <string>
+#include <string.h>
+#include <queue>
+#include <algorithm>
+#include <vector>
+using namespace std;
+
+#define INF 1e9
+#define MAX 20001
+#define my_pair pair<int, int> // pair<int, pair<int, int> >
+
+int V, E, K;
+int result[MAX] = {0,};
+
+vector<pair<int, int>> arr[MAX]; // next, weight
+priority_queue<my_pair, vector<my_pair>, greater<my_pair>> pq; // weight, {u, v}
+
+int main(void) {
+    cin.tie(NULL);
+    ios::sync_with_stdio(false);
+
+    // init
+    cin >> V >> E >> K;
+    for(int i = 0; i < E; i++){
+        int u, v, w; cin >> u >> v >> w;
+        arr[u].push_back({v, w});
+    }
+    for(int i = 1; i <= V; i++) result[i] = INF;
+
+    // start node
+    result[K] = 0;
+    pq.push({0, K});
+
+    while(!pq.empty()){
+        int cur = pq.top().second;
+        int cur_w = pq.top().first;
+        pq.pop();
+
+        if(cur_w > result[cur]) continue;
+
+        for(auto i: arr[cur]){
+            int next = i.first;
+            int next_w = cur_w + i.second;
+
+            if(result[next] > next_w) {
+                result[next] = next_w;
+                pq.push({next_w, next});
+            }
+        }
+    }
+    
+    // print
+    for(int i = 1; i <= V; i++)
+        if(result[i] == INF) cout << "INF\n";
+        else cout << result[i] <<'\n'; 
+
+    return 0;
+}


### PR DESCRIPTION
### 📌 푼 문제들

- [1753_최단경로](https://www.acmicpc.net/problem/1753)
- [13549_숨바꼭질 3](https://www.acmicpc.net/problem/13549)

---

### 📝 간단한 풀이 과정

#### 1753_최단경로 ⭐️⭐️⭐️⭐️⭐️

> `시간복잡도`: O((V+E)logV)
> - V는 정점의 개수
> - E는 한 정점의 주변 노드

- 다익스트라 알고리즘 사용하여 풀었음
- 시간, 공간복잡도 생각 안하고 풀었다가.. 시간 허비했다...
- 일단 인접행렬쓰면 메모리 초과가 나고, priority_queue 안쓰고 모든 간선을 한번씩만 탐색하는 방법은 시간초과가 난다.

#### 13549_숨바꼭질 3

> `시간복잡도`: O(VlogV) 
> - V는 두 사람 사이의 거리
> - 우선순위 큐에 넣고 빼는 과정 1회 당 logV (상수배 생략)
> - 앞서 우선순위 큐에 넣고 빼는 과정을 최악의 경우, V만큼 수행

- 이전이랑 똑같이 풀이했는데, 자꾸 틀렸대서 확인해봤더니
- `*2` → `+1` → `-1` 순서대로 큐에 넣어줘야했음 → [이유 참고](https://www.acmicpc.net/board/view/54741)

---
