### PR TITLE
[감자] 2021.08.02

### DIFF
--- a/dkswndms4782/two_pointer/1806_부분합.cpp
+++ b/dkswndms4782/two_pointer/1806_부분합.cpp
@@ -1,0 +1,28 @@
+#include <iostream>
+using namespace std;
+
+int main(){
+    ios_base::sync_with_stdio(false);
+    cin.tie(NULL);
+    int N,S; cin >> N >> S;
+    int num[100001];
+    for(int i = 0;i<N;i++) cin >> num[i];
+    int start = 0; int end = 0; int result = 100001; int sum = 0;
+    while(end != (N + 1)){
+        if(sum >= S){
+            while(sum >= S && start != end){
+                result = min(result, end-start);
+                sum -= num[start];
+                start++;
+            }
+        }
+        else{
+            if(end == (N+1)) continue;
+            sum += num[end];
+            end++;
+        }
+    }
+
+    if(result == 100001) cout << 0;
+    else cout << result;
+}

--- a/dkswndms4782/two_pointer/3151_합이0.cpp
+++ b/dkswndms4782/two_pointer/3151_합이0.cpp
@@ -1,0 +1,21 @@
+#include <iostream>
+#include <algorithm>
+using namespace std;
+
+int main(){
+    ios_base::sync_with_stdio(false);
+    cin.tie(NULL);
+    int N; cin >> N; int arr[100001];
+    for(int i = 0;i<N;i++) cin >> arr[i];
+    sort(arr, arr + N);
+    long long int count = 0;
+    for(int i = 0; i<(N-2);i++){
+        for(int j = i+1; j<(N-1);j++){
+            int tmp = (-1) * (arr[i] + arr[j]);
+            int i1 = lower_bound(arr+j+1, arr+N, tmp) - arr;
+            int i2 = upper_bound(arr+j+1, arr+N, tmp) - arr;
+            count += (i2 - i1);
+        }
+    }
+    cout << count;
+}


### PR DESCRIPTION
### 📌 푼 문제들

- [부분합](https://www.acmicpc.net/problem/1806)
- [합이0](https://www.acmicpc.net/problem/3151)

---

### 📝 간단한 풀이 과정

#### 부분합

> `시간복잡도`: O(N)

- 합이 S보다 큰 경우 start좌표를 +1 -> 최소 길이 구함
- 합이 S보다 작은 경우 end좌표를 +1

#### 합이0

> `시간복잡도`: O(n^2 log n) (이분탐색을 시행했기때문)

- [여기](https://t-anb.tistory.com/26)를 참고했습니다.
- 각 값을 더한 값의 부호 반대값을 tmp변수에 할당
- lower bound함수는 tmp값보다 큰 값중 가장 작은 값(tmp포함)의 index return(1)
- upper bound함수는 tmp값을 초과하는 값 중 가장 작은 값의 index return(2)
- (2)에서 (1)빼주면 조합의 개수 나옴
- count에 더해준 후 cout


