### PR TITLE
[샐리] 2021.08.03

### DIFF
--- a/sally/README.md
+++ b/sally/README.md
@@ -149,7 +149,7 @@
 - [ ] **15961_회전 초밥** / [문제](https://www.acmicpc.net/problem/15961) / [풀이]()
 - [ ] **1806_부분합** / [문제](https://www.acmicpc.net/problem/1806) / [풀이]()
 - [ ] **3151_합이 0** / [문제](https://www.acmicpc.net/problem/3151) / [풀이]()
-- [ ] **20366_같이 눈사람 만들래?** / [문제](https://www.acmicpc.net/problem/20366) / [풀이]()
-- [ ] **20442_ㅋㅋ루ㅋㅋ** / [문제](https://www.acmicpc.net/problem/20442) / [풀이]()
+- [X] **20366_같이 눈사람 만들래?** / [문제](https://www.acmicpc.net/problem/20366) / [풀이]()
+- [X] **20442_ㅋㅋ루ㅋㅋ** / [문제](https://www.acmicpc.net/problem/20442) / [풀이]()
 
 ---

--- a/sally/README.md
+++ b/sally/README.md
@@ -153,3 +153,62 @@
 - [X] **20442_ㅋㅋ루ㅋㅋ** / [문제](https://www.acmicpc.net/problem/20442) / [풀이]()
 
 ---
+
+## Brute Force
+
+- [ ] 1969_DNA / [문제](https://www.acmicpc.net/problem/1969) / [풀이]()  
+- [ ] 2503_숫자 야구 / [문제](https://www.acmicpc.net/problem/2503) / [풀이]()  
+- [ ] 2422_한윤정이 이탈리아에 가서 아이스크림을 사먹는데 / [문제](https://www.acmicpc.net/problem/2422) / [풀이]()  
+- [ ] 17626_Four Squares / [문제](https://www.acmicpc.net/problem/17626) / [풀이]()  
+- [ ] 5568_카드 놓기 / [문제](https://www.acmicpc.net/problem/5568) / [풀이]()  
+- [ ] 18511_큰 수 구성하기 / [문제](https://www.acmicpc.net/problem/18511) / [풀이]()  
+- [ ] 9079_동전 게임 / [문제](https://www.acmicpc.net/problem/9079) / [풀이]()  
+- [ ] 14501_퇴사 / [문제](https://www.acmicpc.net/problem/14501) / [풀이]()  
+- [ ] 16937_두 스티커 / [문제](https://www.acmicpc.net/problem/16937) / [풀이]()  
+- [ ] 16439_치킨치킨치킨 / [문제](https://www.acmicpc.net/problem/16439) / [풀이]()  
+- [ ] 2615_오목 / [문제](https://www.acmicpc.net/problem/2615) / [풀이]()  
+- [ ] 16508_전공책 / [문제](https://www.acmicpc.net/problem/16508) / [풀이]()  
+- [ ] 14620_꽃길 / [문제](https://www.acmicpc.net/problem/14620) / [풀이]()  
+- [ ] 12919_A와 B 2 / [문제](https://www.acmicpc.net/problem/12919) / [풀이]()  
+- [ ] 1548_부분 삼각 수열 / [문제](https://www.acmicpc.net/problem/1548) / [풀이]()  
+- [ ] 2961_도영이가 만든 맛있는 음식 / [문제](https://www.acmicpc.net/problem/2961) / [풀이]()  
+- [ ] 15661_링크와 스타트 / [문제](https://www.acmicpc.net/problem/15661) / [풀이]()  
+- [ ] 1025_제곱수 찾기 / [문제](https://www.acmicpc.net/problem/1025) / [풀이]()  
+- [ ] 14500_테트로미노 / [문제](https://www.acmicpc.net/problem/14500) / [풀이]()  
+- [ ] 15686_치킨 배달 / [문제](https://www.acmicpc.net/problem/15686) / [풀이]()  
+- [ ] 21278_호석이 두 마리 치킨 / [문제](https://www.acmicpc.net/problem/21278) / [풀이]()  
+- [ ] 21315_카드 섞기 / [문제](https://www.acmicpc.net/problem/21315) / [풀이]()  
+- [ ] 16637_괄호 추가하기 / [문제](https://www.acmicpc.net/problem/16637) / [풀이]()  
+- [ ] 14391_종이 조각 / [문제](https://www.acmicpc.net/problem/14391) / [풀이]()  
+- [ ] 18808_스티커 붙이기 / [문제](https://www.acmicpc.net/problem/18808) / [풀이]()  
+
+---
+
+## Simulation
+
+- [ ] 16234_인구 이동 / [문제](https://www.acmicpc.net/problem/16234) / [풀이]()  
+- [ ] 17144_미세먼지 안녕! / [문제](https://www.acmicpc.net/problem/17144) / [풀이]()  
+- [ ] 20056_마법사 상어와 파이어볼 / [문제](https://www.acmicpc.net/problem/20056) / [풀이]()  
+- [ ] 21610_마법사 상어와 비바라기 / [문제](https://www.acmicpc.net/problem/21610) / [풀이]()  
+- [ ] 16236_아기 상어 / [문제](https://www.acmicpc.net/problem/16236) / [풀이]()  
+- [ ] 15685_드래곤 커브 / [문제](https://www.acmicpc.net/problem/15685) / [풀이]()  
+- [ ] 16235_나무 재테크 / [문제](https://www.acmicpc.net/problem/16235) / [풀이]()  
+- [ ] 17135_캐슬 디펜스 / [문제](https://www.acmicpc.net/problem/17135) / [풀이]()  
+- [ ] 17140_이차원 배열과 연산 / [문제](https://www.acmicpc.net/problem/17140) / [풀이]()  
+- [ ] 17779_게리맨더링 2 / [문제](https://www.acmicpc.net/problem/17779) / [풀이]()  
+- [ ] 19238_스타트 택시 / [문제](https://www.acmicpc.net/problem/19238) / [풀이]()  
+- [ ] 20057_마법사 상어와 토네이도 / [문제](https://www.acmicpc.net/problem/20057) / [풀이]()  
+- [ ] 20058_마법사 상어와 파이어스톰 / [문제](https://www.acmicpc.net/problem/20058) / [풀이]()  
+- [ ] 17822_원판 돌리기 / [문제](https://www.acmicpc.net/problem/17822) / [풀이]()  
+- [ ] 19237_어른 상어 / [문제](https://www.acmicpc.net/problem/19237) / [풀이]()  
+- [ ] 20436_ZOAC 3 / [문제](https://www.acmicpc.net/problem/20436) / [풀이]()  
+- [ ] 5212_지구 온난화 / [문제](https://www.acmicpc.net/problem/5212) / [풀이]()  
+- [ ] 1713_후보 추천하기 / [문제](https://www.acmicpc.net/problem/1713) / [풀이]()  
+- [ ] 20055_컨베이어 벨트 위의 로봇 / [문제](https://www.acmicpc.net/problem/20055) / [풀이]()  
+- [ ] 14891_톱니바퀴 / [문제](https://www.acmicpc.net/problem/14891) / [풀이]()  
+- [ ] 15683_감시 / [문제](https://www.acmicpc.net/problem/15683) / [풀이]()  
+- [ ] 20165_인내의 도미노 장인 호석 / [문제](https://www.acmicpc.net/problem/20165) / [풀이]()  
+- [ ] 21922_학부 연구생 민상 / [문제](https://www.acmicpc.net/problem/21922) / [풀이]()  
+
+---
+

--- a/sally/two_pointer/20366_같이 눈사람 만들래.cpp
+++ b/sally/two_pointer/20366_같이 눈사람 만들래.cpp
@@ -1,0 +1,48 @@
+/*
+# Two pointer
+# Problem: 20366
+# Memory: 2024KB
+# Time: 180ms
+*/
+#include <iostream>
+#include <vector>
+#include <cmath>
+#include <algorithm>
+#include <string.h>
+#include <string>
+#include <queue>
+using namespace std;
+
+int N;
+vector<int> v;
+vector<pair<int, int>> pairs;
+int result = 1e9;
+
+int main(void) {
+	cin.tie(NULL);
+    ios::sync_with_stdio(false);
+
+	cin >> N;
+	for(int i = 0; i < N; i++){
+		int a; cin >> a;
+		v.push_back(a);
+	}
+	sort(v.begin(), v.end());
+
+	for(int i = 0; i < N-3; i++){
+		for(int j = i+3; j < N; j++){
+			int l = i+1;
+			int r = j-1;
+			while(l < r){
+				int tmp = v[i] + v[j] - (v[l] + v[r]);
+				result = min(result, abs(tmp));
+				if(tmp > 0) l++;
+				else r--;
+			}
+		}
+	}
+
+	cout << result << '\n';
+
+	return 0;
+}

--- a/sally/two_pointer/20442_ㅋㅋ루ㅋㅋ.cpp
+++ b/sally/two_pointer/20442_ㅋㅋ루ㅋㅋ.cpp
@@ -1,0 +1,65 @@
+/*
+# Two pointer
+# Problem: 20442
+# Memory: 31728KB
+# Time: 68ms
+*/
+#include <iostream>
+#include <vector>
+#include <cmath>
+#include <algorithm>
+#include <string.h>
+#include <string>
+#include <queue>
+using namespace std;
+
+#define MAX 3000001
+
+string str;
+int a_ind = 0;
+int b_ind = 0;
+
+
+int R[MAX] = {0,};
+int K[MAX] = {0,};
+
+int max_lr = 0;
+int r_cnt = 0;
+int k_cnt = 0;
+int result = 0;
+
+int main(void) {
+	cin.tie(NULL);
+    ios::sync_with_stdio(false);
+	
+	cin >> str;
+	int s_len = str.size();
+
+	for(int i = 0; i < s_len; i++){
+		if (str[i] == 'R')
+			r_cnt++;
+		if (str[i] == 'K')
+			k_cnt++;
+		R[i] = r_cnt;
+		K[i] = k_cnt;
+	}
+
+	int a = 0;
+	int b = s_len - 1;
+
+	while(a <= b){
+		int target = -1;
+		int l = K[s_len - 1] - K[b];
+		if (str[b] == 'K') l++; // 예외처리 중요 // KKKR
+		if (R[b] - R[a] > 0)
+			target = R[b] - R[a] + (2 * min(K[a], l));
+		result = max(result, target);
+		
+		if(K[a] < l) a++;
+		else b--;
+	}
+
+	cout << max(result, r_cnt);
+
+	return 0;
+}


### PR DESCRIPTION
### 📌 푼 문제들

- [20442_ㅋㅋ루ㅋㅋ](https://www.acmicpc.net/problem/20442)
- [20366_같이 눈사람 만들래?](https://www.acmicpc.net/problem/20366)

---

### 📝 간단한 풀이 과정

#### 20442_ㅋㅋ루ㅋㅋ

> `시간복잡도`: O(N)

- 문제 해석과 예외처리에 시간을 많이 들였다.
- K의 수와 R의 수를 누적해서 저장해둔다.
- a 포인터는 앞에서부터, b 포인터는 뒤에서부터 탐색을 시작
- 각각 앞에서부터, 뒤에서부터 카운트한 K의 수를 사용한다. (각각을 A, B라고 해보자)
  - 앞에서부터 K의 수를 카운트한 값: K[a] → **A**
  - 뒤에서부터 K의 수를 카운트한 값: K[`문자열길이 - 1`] - K[b] → **B**
- A가 더 큰 경우에는 B가 한칸 앞으로 와야한다.
- B가 더 큰 경우에는 A가 한칸 뒤로 가야한다.
  - 해당 부분 → `if(K[a] < l) a++; else b--;`
- 예외처리 힘들었던 부분: 
  - `int l = K[s_len - 1] - K[b];`
  - `if (str[b] == 'K') l++; // 예외처리 중요 // KKKR`
- 왜 계속 틀렸냐면...
  - RKRR의 경우에는, K[] = 0,1,1,1 (마지막에 R이 오는 경우)
  - RKKK의 경우에는, K[] = 0,1,2,3 (마지막에 K가 오는 경우)
  - 뒤에서부터 수를 셀 때, `int l = K[s_len - 1] - K[b] + 1;` 이렇게 두고 풀었을 때, "RKRR"의 경우에 문제가 생겼음
  - → K가 없는데 1개로 카운트하는 오류
  - 그래서 기본적으로 `int l = K[s_len - 1] - K[b];` 이렇게 두고, `str[b] == 'K'` 조건을 만족할 때, +1을 해줌

#### 20366_같이 눈사람 만들래?

> `시간복잡도`: O(N^3)

- 첫 풀이는, 눈덩이를 정렬하고, 인접한 눈덩이와의 차이를 이용하고자 했다.
  1. 눈덩이 정렬
  2. pair{인접 눈덩이 간 크기 차이, 눈덩이 위치(인덱스)} 벡터를 만들어 정렬 → 인접 눈덩이간 차이가 가장 덜 나는 순서대로 정렬될 것이다.
  3. 가장 차이가 안나는 두 덩이를 골라서 각자 크로스해서 더해줌 (a, a+1), (b, b+1) 있으면, `(a, b+1) - (a+1, b)` 이렇게?
- 여튼 위에 방법은 예외 케이스가 있어서 사용 불가능하다.
  -  예를들면, `3, 4, 5, 7`보다는, `3, 7, 10, 14` 이렇게 고르는게 더 나을때가 있기 때문이다.
- 바뀐 풀이는 앞에서부터 범위를 늘려가며, `늘어난 범위 내의 두 점을 골라서 더한 값`과 `선택한 범위의 양 끝 값의 합`과 비교하는 것이다.
- 이 방법이 시간안에 들어올 줄 몰랐다.

---