### PR TITLE
[감자] 2021.08.09

### DIFF
--- a/dkswndms4782/brute_force/14501_퇴사.cpp
+++ b/dkswndms4782/brute_force/14501_퇴사.cpp
@@ -1,0 +1,21 @@
+#include <iostream>
+#include <vector>
+using namespace std;
+
+int N; int T,P; vector<pair<int,int>>v; int result = -1;
+void func(int now, int sum){
+    if(now > N) return;
+    if(now == N) {if(result < sum) {result = sum;} return;}
+    func(now + v[now].first, sum + v[now].second);
+    func(now + 1, sum);
+}
+
+int main(){
+    cin >> N; int t,p;
+    for(int i = 0;i<N;i++){
+        cin >> t >> p;
+        v.push_back({t,p});
+    }
+    func(0,0);
+    cout << result;
+}

--- a/dkswndms4782/brute_force/9079_동전게임.cpp
+++ b/dkswndms4782/brute_force/9079_동전게임.cpp
@@ -1,0 +1,33 @@
+#include <iostream>
+using namespace std;
+
+char coin[3][3];
+pair<int,int> arr[8][3] = {{{0,0},{0,1},{0,2}},{{1,0},{1,1},{1,2}},{{2,0},{2,1},{2,2}},
+                            {{0,0},{1,0},{2,0}},{{0,1},{1,1},{2,1}},{{0,2},{1,2},{2,2}},
+                            {{0,0},{1,1},{2,2}},{{2,0},{1,1},{0,2}}};
+
+int main(){
+    int T; cin >> T;
+    for(int i = 0;i<T;i++){
+        for(int j = 0;j<3;j++) for(int k = 0;k<3;k++) cin >> coin[j][k];
+        int result = 9;
+        for(int j = 0;j<(1<<8);j++){
+            int cnt = 0; char tmp[3][3];
+            for(int a = 0;a<3;a++) for(int b = 0;b < 3;b++) tmp[a][b] = coin[a][b];
+            for(int k = 0;k<8;k++){
+                if(j & (1<<k)){
+                    cnt++;
+                    for(int a = 0;a<3;a++){
+                        if(tmp[arr[k][a].first][arr[k][a].second] == 'T') tmp[arr[k][a].first][arr[k][a].second] = 'H';
+                        else tmp[arr[k][a].first][arr[k][a].second] = 'T';
+                    }
+                }
+            }
+            char now = tmp[0][0]; bool flag = true;
+            for(int a = 0;a<3;a++) for(int b = 0;b<3;b++) if(now != tmp[a][b]) flag = false;
+            if(flag && result > cnt) result = cnt;
+        }
+        if(result == 9) cout << -1 << "\n";
+        else cout << result << "\n";
+    }
+}


### PR DESCRIPTION
### 📌 푼 문제들

- [동전게임](https://www.acmicpc.net/problem/9079)
- [퇴사](https://www.acmicpc.net/problem/14501)

---

### 📝 간단한 풀이 과정

#### 동전게임

> `시간복잡도`: O(T * 2^N) (N : 판의 크기)

- 각 뒤집을 수 있는 행(가로,세로,대각선)을 배열에 8x3x2의 형태로 저장
- 비트마스크를 이용하여 8개의 비트를 나타내고, 각 자리가 1인지 0인지에 따라 그 자리에 해당하는 행을 뒤집을지 말지 결정
- 총 2*8의 동전을 뒤집는 경우의 수가 나오고, 뒤집었을 때 판이 다 똑같은 면일 경우 result갱신
- 출력

#### 퇴사

> `시간복잡도`: O(N)..?...

- 재귀를 사용하여 풂
- 현재 상담 날짜가 N과 같으면 result갱신, return
- 현재 상담 날짜가 N보다 크면 return
- 현재 상담 날짜가 N보다 작으면 {1)현재 상담 X, 다음 날짜로 재귀 2)현재 상담 O, 다음 가능 날짜로 재귀} 이렇게 재귀

