### PR TITLE
[튜브] 2021.08.10

### DIFF
--- a/peacecheejecake/README.md
+++ b/peacecheejecake/README.md
@@ -89,3 +89,5 @@
 |8/4|2503|숫자 야구|[link](https://www.acmicpc.net/problem/2503)|
 |8/5|2422|한윤정이 이탈리아에 가서 아이스크림을 사먹는데|[link](https://www.acmicpc.net/problem/2422)|
 |8/5|17626|Four Squares|[link](https://www.acmicpc.net/problem/17626)|
+|8/10|16937|두 스티커|[link](https://www.acmicpc.net/problem/16937)|
+|8/10|16439|치킨치킨치킨|[link](https://www.acmicpc.net/problem/16439)|

--- a/peacecheejecake/brute_force/16439_치킨치킨치킨.py
+++ b/peacecheejecake/brute_force/16439_치킨치킨치킨.py
@@ -1,0 +1,21 @@
+# https://www.acmicpc.net/problem/16439
+# 31312 KB / 256 ms
+
+
+from itertools import permutations
+
+
+N, M = map(int, input().split())
+chicken_matrix = []
+for _ in range(N):
+    chicken_matrix.append([int(p) for p in input().split()])
+
+max_pref_sum = 0
+for c1, c2, c3 in permutations(range(M), 3):
+    pref_sum = 0
+    for prefs in chicken_matrix:
+        pref = max(prefs[c1], prefs[c2], prefs[c3])
+        pref_sum += pref
+    max_pref_sum = max(max_pref_sum, pref_sum)
+
+print(max_pref_sum)

--- a/peacecheejecake/brute_force/16937_두스티커.py
+++ b/peacecheejecake/brute_force/16937_두스티커.py
@@ -1,0 +1,35 @@
+# https://www.acmicpc.net/problem/16937
+# 31312 KB / 96 ms
+
+
+from itertools import permutations
+from math import prod
+
+
+def check(wi, wj, hi, hj, H, W):
+    if (wi + wj <= W and max(hi, hj) <=H or
+        max(wi, wj) <= W and hi + hj <= H):
+        return True
+    return False
+
+
+H, W = map(int, input().split())
+N = int(input())
+stickers = [tuple(map(int, input().split())) for _ in range(N)]
+
+max_area = 0
+for i, j in permutations(range(N), 2):
+    sum_area = prod(stickers[i]) + prod(stickers[j])
+    if sum_area > H * W:
+        continue
+    ri, ci = stickers[i]
+    rj, cj = stickers[j]
+    pairs = [(ri, rj), (ri, cj), (ci, rj), (ci, cj)]
+    for p in range(len(pairs)):
+        wi, wj = pairs[p]
+        hi, hj = pairs[-(p + 1)]
+        if check(wi, wj, hi, hj, H, W):
+            max_area = max(max_area, sum_area)
+            break
+
+print(max_area)


### PR DESCRIPTION
### 📌 푼 문제들

- [두 스티커](https://www.acmicpc.net/problem/16937)
- [치킨치킨치킨](https://www.acmicpc.net/problem/16439)

---

### 📝 간단한 풀이 과정

#### 두 스티커

> `시간복잡도`: O(N^2) 

- 순열을 이용해 스티커를 두 개씩 뽑는다.
- 두 스티커의 넓이 합이 모눈종이 넓이보다 큰지 검사한다.
- 스티커를 90도씩 돌릴 수 있으므로, 각각의 쌍마다 네 가지 경우를 검사한다. 이 때 한 쪽 방향은 더하고, 한 쪽 방향은 둘 중 최댓값을 택해서 모눈종이 한 변 길이와 비교한다.
- 네 가지 경우 중 조건을 만족하는 경우가 발견되면, 최댓값을 갱신하고 다음 두 스티커를 찾는다.

#### 치킨치킨치킨

> `시간복잡도`: O(NM^3)

- 순열을 이용해 세 가지 치킨을 고르고, 모든 경우를 완전탐색한다.