### PR TITLE
[감자] 2021.08.10

### DIFF
--- a/dkswndms4782/brute_force/16439_치킨치킨치킨.cpp
+++ b/dkswndms4782/brute_force/16439_치킨치킨치킨.cpp
@@ -1,0 +1,32 @@
+#include <iostream>
+#include <algorithm>
+#include <vector>
+using namespace std;
+
+int N,M;
+int ch[31][31];
+int result = -1;
+
+int main(){
+    ios_base::sync_with_stdio(false);
+    cin.tie(NULL);
+    cin >> N >> M;
+    for(int i = 0;i<N;i++) for(int j = 0;j<M;j++) cin >> ch[i][j];
+    vector<int>v(M); v[0] = v[1] = v[2] = -1;  
+    do{ 
+        vector<int>brand;
+        for(int i = 0;i<M;i++){
+            if(v[i] == -1) brand.push_back(i);
+        }
+        int sum = 0;
+        for(int i = 0;i<N;i++){
+            int max_num = -1;
+            for(int j = 0;j<3;j++){
+                if(max_num < ch[i][brand[j]]) max_num = ch[i][brand[j]];
+            }
+            sum += max_num;
+        }
+        if(sum > result) result = sum;
+    }while(next_permutation(v.begin(), v.end()));
+    cout << result;
+}

--- a/dkswndms4782/brute_force/16937_두스티커.cpp
+++ b/dkswndms4782/brute_force/16937_두스티커.cpp
@@ -1,0 +1,43 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+using namespace std;
+
+int H,W,R,C,N;
+vector<pair<int,int>>sticker;
+
+bool check(pair<int,int>a, pair<int,int>b){
+    if(a.first + b.first <= H && max(a.second, b.second) <= W) return true;
+    if(a.second + b.second <= W && max(a.first, b.first) <= H) return true;
+    //a돌리기
+    if(a.second + b.first <= H && max(a.first, b.second) <= W) return true;
+    if(a.first + b.second <= W && max(a.second, b.first) <= H) return true;
+    //b돌리기
+    if(a.first + b.second <= H && max(a.second, b.first) <= W) return true;
+    if(a.second + b.first <= W && max(a.first, b.second) <= H) return true;
+    //둘다 돌리기
+    if(a.second + b.second <= H && max(a.first, b.first) <= W) return true;
+    if(a.first + b.first <= W && max(a.second, b.second) <= H) return true;
+
+    return false;
+}
+
+int main(){
+    cin >> H >> W >> N;
+    if(N == 1) {cout << 0; return 0;}
+    for(int i = 0;i<N;i++){
+        cin >> R >> C;
+        sticker.push_back({R,C});
+    }
+    vector<int>v(N); v[0] = v[1] = -1;
+    int result = -1;
+    do{
+        vector<int>now_sticker; 
+        for(int i = 0;i<N;i++) if(v[i] == -1) now_sticker.push_back(i);
+        if(check(sticker[now_sticker[0]], sticker[now_sticker[1]])) 
+            result = max(result, sticker[now_sticker[0]].first*sticker[now_sticker[0]].second + sticker[now_sticker[1]].first*sticker[now_sticker[1]].second);
+    }while(next_permutation(v.begin(), v.end()));
+    if(result == -1) cout << 0;
+    else cout << result;
+}
+// 2개 더한게 길이와 같거나 작아야함. 나머지 하나중 max는 길이와 같거나 작기


### PR DESCRIPTION
### 📌 푼 문제들

- [두 스티커](https://www.acmicpc.net/problem/16937)
- [치킨치킨치킨](https://www.acmicpc.net/problem/16439)

---

### 📝 간단한 풀이 과정

#### 두 스티커

> `시간복잡도`: O(N*2)(permutation * N번 돌면서 -1값 찾기)

- 순열을 이용해 2개의 스티커 뽑음
- 스티커 두개의 세로를 더한 길이가 H보다 작거나 같고, 가로의 값중 큰 값이 W보다 작거나 같으면 현재 스티커 2개 사용가능(가로, 세로 반대도 마찬가지) 
- 스티커를 돌리는 경우의 수는 (돌리는 것:1, 원래 : 0){(0,0), (1,0), (0,1), (1,1)}이 있음
- 8개의 경우에서 하나라도 참이 되면 두 스티커의 넓이를 더해 최댓값 갱신

#### 치킨치킨치킨

> `시간복잡도`: O(N(N+M))(permution*(M만큼 돌며 -1값인지 확인 + 회원 전체 확인))

- 순열로 3개의 치킨 브랜드를 뽑음
- 각 회원별로 3개의 치킨 브랜드 중 가장 큰 값을 가지고 있는것을 sum에 더해줌
- result와 sum값을 비교해 최댓값 갱신 

---
