### PR TITLE
[샐리] 2021.10.17

### DIFF
--- a/sally/leetcode/139_Word Break.cpp
+++ b/sally/leetcode/139_Word Break.cpp
@@ -1,0 +1,27 @@
+// 139. Word Break
+// Runtime: 40 ms, faster than 15.17 % of C++ online submissions for Word Break.
+// Memory Usage : 13.1 MB, less than 51.69 % of C++ online submissions for Word Break.
+// ref: https://leetcode.com/problems/word-break/discuss/43814/C%2B%2B-Dynamic-Programming-simple-and-fast-solution-(4ms)-with-optimization
+
+class Solution {
+public:
+    bool dp[302] = { false, };
+    bool wordBreak(string s, vector<string>& words) {
+        int s_len = s.size();
+        dp[0] = true;
+        for (int i = 1; i <= s_len; i++) {
+            for (int j = 0; j < i; j++) {
+                if (dp[j]) {
+                    string target = s.substr(j, i - j);
+                    for (auto k : words)
+                        if (k == target) {
+                            dp[i] = true;
+                        }
+                }
+            }
+        }
+        for (auto i : dp) cout << i << ' ';
+        cout << '\n';
+        return dp[s_len];
+    }
+};

--- a/sally/leetcode/207_Course Schedule.cpp
+++ b/sally/leetcode/207_Course Schedule.cpp
@@ -1,0 +1,39 @@
+// 207. Course Schedule
+// Runtime: 60 ms, faster than 8.89 % of C++ online submissions for Course Schedule.
+// Memory Usage : 16.8 MB, less than 8.35 % of C++ online submissions for Course Schedule.
+// ref: https://leetcode.com/problems/course-schedule/discuss/1519258/Easy-C%2B%2B-Solution-using-cycle-detection-in-a-directed-graph
+
+class Solution {
+public:
+#define MAX 100001
+
+    int N;
+    vector<int> v[MAX];
+    bool visit[MAX];
+    bool visit_all[MAX];
+
+    bool dfs(int cur) {
+        visit_all[cur] = visit[cur] = true;
+        for (auto i : v[cur]) {
+            if (visit[i]) return false;
+            else if (!visit_all[i]) {
+                if (!dfs(i)) return false;
+            }
+        }
+        visit[cur] = false;
+        return true;
+    }
+
+    bool canFinish(int numCourses, vector<vector<int>>& prerequisites) {
+        // init
+        N = numCourses;
+        for (auto i : prerequisites)
+            v[i[0]].push_back(i[1]);
+
+        // check cycle
+        for (int i = 0; i < N; i++)
+            if (!visit_all[i] && !dfs(i)) return false;
+
+        return true;
+    }
+};

--- a/sally/leetcode/242_Valid Anagram.cpp
+++ b/sally/leetcode/242_Valid Anagram.cpp
@@ -1,0 +1,17 @@
+// 242. Valid Anagram
+// Runtime: 10 ms, faster than 59.04 % of C++ online submissions for Valid Anagram.
+// Memory Usage : 7.4 MB, less than 7.00 % of C++ online submissions for Valid Anagram.
+
+class Solution {
+public:
+    bool isAnagram(string s, string t) {
+        int alpha[26] = { 0, };
+        int s_len = s.size();
+        int t_len = t.size();
+        for (int i = 0; i < s_len; i++) alpha[s[i] - 'a']++;
+        for (int i = 0; i < t_len; i++) alpha[t[i] - 'a']--;
+        for (int i = 0; i < 26; i++)
+            if (alpha[i] != 0) return false;
+        return true;
+    }
+};

--- a/sally/leetcode/435_Non-overlapping Intervals.cpp
+++ b/sally/leetcode/435_Non-overlapping Intervals.cpp
@@ -1,0 +1,22 @@
+// 435. Non-overlapping Intervals
+// Runtime: 416 ms, faster than 63.83 % of C++ online submissions for Non - overlapping Intervals.
+// Memory Usage : 89.8 MB, less than 47.00 % of C++ online submissions for Non - overlapping Intervals.
+// ref: https://leetcode.com/problems/non-overlapping-intervals/discuss/1520653/C%2B%2B-Sorting
+
+class Solution {
+public:
+    int eraseOverlapIntervals(vector<vector<int>>& intervals) {
+        sort(intervals.begin(), intervals.end());
+        int end_point = intervals[0][1];
+        int ans = 0;
+        int intervals_len = intervals.size();
+        for (int i = 1; i < intervals_len; i++) {
+            if (intervals[i][0] < end_point) {
+                ans++;
+                end_point = min(end_point, intervals[i][1]);
+            }
+            else end_point = intervals[i][1];
+        }
+        return ans;
+    }
+};


### PR DESCRIPTION
### 📌 푼 문제들

- [242. Valid Anagram](https://leetcode.com/problems/valid-anagram/)
- [435. Non-overlapping Intervals](https://leetcode.com/problems/non-overlapping-intervals/)
- [207. Course Schedule](https://leetcode.com/problems/course-schedule/)
- [139. Word Break](https://leetcode.com/problems/word-break/)

---

### 📝 간단한 풀이 과정

#### 242. Valid Anagram

- 알파벳 소문자 길이의 int 배열(alpha)을 생성
- string s는 각 자리의 문자에 해당하는 배열의 값을 1씩 더해주고, 반대로 string t는 각 자리의 문자에 해당하는 배열의 값을 1씩 빼준다.
- alpha 배열의 모든 값이 0인지 확인한다.

#### 435. Non-overlapping Intervals 

- [참고](https://leetcode.com/problems/non-overlapping-intervals/discuss/1520653/C%2B%2B-Sorting)
- 우선, 인풋으로 들어오는 벡터를 정렬한다.
- 각 interval 벡터가 오버랩이 되는 경우와 오버랩이 되지 않는 경우로 나누어서 생각한다.
- 오버랩이 안되는 경우는 interval[i-1][1] <= interval[i][0]인 경우이다.
- 오버랩이 되는 경우, 지워야하는 interval의 수를 하나 증가시키고, 끝부분이 더 앞에 있는 interval을 선택하여 남겨둔다. (다음 interval과 비교하기 위해)

#### 207. Course Schedule

- [참고](https://leetcode.com/problems/course-schedule/discuss/1519258/Easy-C%2B%2B-Solution-using-cycle-detection-in-a-directed-graph)
- DFS로 풀다가 시간초과나서 결국 discussion 봐버렸다..
- 전체 노드의 방문 여부를 담는 bool 형 `visit_all `배열과 한 사이클을 돌면서 방문여부를 체크하는 visit 배열이 있다.
- 전체 노드를 순환하며, `visit_all`이 false인 노드에 대해 dfs 함수를 실행시킨다. 
- dfs 함수는 인자로 받은 노드에 연결된 선수강 과목을 재귀적으로 확인하는 역할을 한다.
- 재귀적으로 연결된 노드를 인자로 준 dfs 함수를 호출하기 전, `visit[현재노드]`를 true로 변경해준다.
- 만약 `visit[방문할 노드]` 값이 이미 true인 경우, 사이클이 발견된 경우이므로, 바로 false를 반환한다.
- 만약 현재 사이클에서 방문하지 않았더라도 `visit_all`에서 방문한 경우라면, 이미 그 노드를 통해 지나간 길의 끝은 사이클이 없다는 것이 증명된 상태이므로 뛰어넘는다.
- 이 경우도 아니라면, dfs를 통해서 더 깊이 있는 노드까지 탐색해봐야한다.(그 끝에 사이클이 있으면 계속해서 false를 return하게 될 것이다.)

#### 139. Word Break

- [참고](https://leetcode.com/problems/word-break/discuss/43814/C%2B%2B-Dynamic-Programming-simple-and-fast-solution-(4ms)-with-optimization)
- dp를 사용한다.
- 앞에서부터 확인하게 된다. 확인하는 문자열의 인덱스를 i라고 하자.
- (`어떤 인덱스` ~ `i-1`) 까지의 문자열이 존재하는 경우에만 `dp[i]`를 true로 만들 수 있다고 하자.
- (어떤 수 `j` ~ `i-1`) substring을 만들고, 이 substring이 주어진 words 벡터 안에 존재하는지 확인한다.
- 존재한다면, `dp[j]`에 들어있는 true/false 값 중 하나를 가져오게 된다.
- 만약에 (`j` ~ `i-1`) substring이 존재하더라도 `dp[j]`가 false라면, j인덱스까지의 부분문자열을 만들 수 없었다는 의미가 되므로, 이 방식이 correct를 받을 수 있었던 것 같다.

---

ㅜㅜ 어렵네요

---
