### PR TITLE
[튜브] 2021.12.18.

### DIFF
--- a/peacecheejecake/programmers/12973_짝지어제거하기.py
+++ b/peacecheejecake/programmers/12973_짝지어제거하기.py
@@ -1,0 +1,8 @@
+def solution(s):
+    stack = []
+    for char in s:
+        if stack and stack[-1] == char:
+            stack.pop()
+        else:
+            stack.append(char)
+    return int(not stack)

--- a/peacecheejecake/programmers/17677_뉴스클러스터링.py
+++ b/peacecheejecake/programmers/17677_뉴스클러스터링.py
@@ -1,0 +1,19 @@
+import re
+from collections import Counter
+
+
+def count_pairs(s):
+    pairs = re.findall(r'(?=([a-z]{2}))', s.lower())
+    return Counter(pairs)
+
+
+def solution(*strs):
+    set1, set2 = map(count_pairs, strs)
+    num_inter, num_union = 0, 0
+    for pair in set(set1) | set(set2):
+        count1 = set1.get(pair, 0)
+        count2 = set2.get(pair, 0)
+        num_inter += min(count1, count2)
+        num_union += max(count1, count2)
+    score = num_inter / num_union if num_union > 0 else 1
+    return int(score * 65536)

--- a/peacecheejecake/programmers/17677_뉴스클러스터링.py
+++ b/peacecheejecake/programmers/17677_뉴스클러스터링.py
@@ -9,7 +9,7 @@ def count_pairs(s):
 
 def solution(*strs):
     set1, set2 = map(count_pairs, strs)
-    num_inter, num_union = 0, 0
+    num_inter, num_union = 0, 0 # 교집합 개수, 합집합 개수
     for pair in set(set1) | set(set2):
         count1 = set1.get(pair, 0)
         count2 = set2.get(pair, 0)

--- a/peacecheejecake/programmers/43166_타겟넘버.py
+++ b/peacecheejecake/programmers/43166_타겟넘버.py
@@ -1,0 +1,9 @@
+def solution(numbers, target):
+    l = len(numbers)
+    answer = 0
+    for i in range(1 << l):
+        signs = f"{i:0{l}b}" # 0이면 +, 1이면 -
+        case = sum((-1) ** int(t) * num for t, num in zip(signs, numbers))
+        answer += int(case == target)
+    return answer
+    

--- a/peacecheejecake/programmers/43166_타겟넘버.py
+++ b/peacecheejecake/programmers/43166_타겟넘버.py
@@ -6,4 +6,3 @@ def solution(numbers, target):
         case = sum((-1) ** int(t) * num for t, num in zip(signs, numbers))
         answer += int(case == target)
     return answer
-    

--- a/peacecheejecake/programmers/60058_괄호변환.py
+++ b/peacecheejecake/programmers/60058_괄호변환.py
@@ -1,9 +1,9 @@
-def solution(p):
+def solution(p): # 
     b = p.replace('(', '1').replace(')', '0')
     return convert(b).replace('1', '(').replace('0', ')')
         
 
-def convert(b):
+def convert(b): # 메인 함수
     if not b:
         return ''
     
@@ -17,7 +17,7 @@ def convert(b):
     return nb
 
 
-def is_right(b):
+def is_right(b): # `올바른 괄호 문자열`인지 검사한다.
     stack = []
     for d in b:
         if stack and stack[-1] != d:
@@ -29,7 +29,7 @@ def is_right(b):
     return not stack
 
 
-def find_u(b):
+def find_u(b): # 최소 길이의 `균형잡힌 괄호 문자열`을 찾는다.
     count = 0
     nb = ''
     for d in b:
@@ -40,7 +40,7 @@ def find_u(b):
     return nb
 
 
-def reverse(b):
+def reverse(b): # 이진수로 나타낸 괄호를 뒤집는다.
     if not b:
         return ''
     return f"{int('1' * len(b), 2) ^ int(b, 2):0{len(b)}b}"

--- a/peacecheejecake/programmers/60058_괄호변환.py
+++ b/peacecheejecake/programmers/60058_괄호변환.py
@@ -1,0 +1,46 @@
+def solution(p):
+    b = p.replace('(', '1').replace(')', '0')
+    return convert(b).replace('1', '(').replace('0', ')')
+        
+
+def convert(b):
+    if not b:
+        return ''
+    
+    u = find_u(b)
+    v = b[len(u):]
+    
+    if is_right(u):
+        nb = u + convert(v)
+    else:
+        nb = '1' + convert(v) + '0' + reverse(u[1:-1])
+    return nb
+
+
+def is_right(b):
+    stack = []
+    for d in b:
+        if stack and stack[-1] != d:
+            stack.pop()
+        else:
+            if not stack and d == '0':
+                return False
+            stack.append(d)
+    return not stack
+
+
+def find_u(b):
+    count = 0
+    nb = ''
+    for d in b:
+        count += (-1) ** int(d)
+        nb += d
+        if count == 0:
+            break
+    return nb
+
+
+def reverse(b):
+    if not b:
+        return ''
+    return f"{int('1' * len(b), 2) ^ int(b, 2):0{len(b)}b}"

--- a/peacecheejecake/programmers/72411_메뉴리뉴얼.py
+++ b/peacecheejecake/programmers/72411_메뉴리뉴얼.py
@@ -6,7 +6,7 @@ def solution(orders, course):
     counter = {num: defaultdict(int) for num in course}
     for order in orders:
         for num in course:
-            if num > len(order):
+            if num > len(order): # 불가능한 경우
                 break
             for comb in combinations(sorted(order), num):
                 counter[num][''.join(comb)] += 1

--- a/peacecheejecake/programmers/72411_메뉴리뉴얼.py
+++ b/peacecheejecake/programmers/72411_메뉴리뉴얼.py
@@ -1,0 +1,20 @@
+from collections import defaultdict
+from itertools import combinations
+
+
+def solution(orders, course):
+    counter = {num: defaultdict(int) for num in course}
+    for order in orders:
+        for num in course:
+            if num > len(order):
+                break
+            for comb in combinations(sorted(order), num):
+                counter[num][''.join(comb)] += 1
+                
+    cands = []
+    for count_dict in counter.values():
+        if count_dict:
+            max_count = max(count_dict.values())
+            if max_count >= 2:
+                cands.extend(k for k, v in count_dict.items() if v == max_count)
+    return sorted(cands)

--- a/peacecheejecake/programmers/77485_행렬테두리회전하기.py
+++ b/peacecheejecake/programmers/77485_행렬테두리회전하기.py
@@ -1,0 +1,26 @@
+def solution(rows, columns, queries):
+    matrix = []
+    for r in range(rows):
+        matrix.append([r * columns + c + 1 for c in range(columns)])
+    
+    result = []
+    for query in queries:
+        rt, ct, rb, cb = (z - 1 for z in query) # 좌표를 0부터 시작하게 변경
+        corners = [(rt, ct), (rt, cb), (rb, cb), (rb, ct)] # 네 모서리 좌표; 왼쪽 위부터 시계방향
+        coords, elements = [], []
+        for i, (ro, co) in enumerate(corners):
+            rn, cn = corners[(i + 1) % 4]
+            if rn == ro: # 좌/우
+                for c in range(co, cn, (cn - co) // abs(cn - co)):
+                    coords.append((ro, c))
+                    elements.append(matrix[ro][c])
+            elif cn == co: # 상/하
+                for r in range(ro, rn, (rn - ro) // abs(rn - ro)):
+                    coords.append((r, co))
+                    elements.append(matrix[r][co])
+        
+        result.append(min(elements)) # 해당 query에서의 최솟값
+        for i, (r, c) in enumerate(coords):
+            matrix[r][c] = elements[i - 1] # 이전(시계 반대 방향) 칸의 원소를 입력
+    
+    return result


### PR DESCRIPTION
### 📌 푼 문제들

- [메뉴 리뉴얼](https://programmers.co.kr/learn/courses/30/lessons/72411)
- [괄호 변환](https://programmers.co.kr/learn/courses/30/lessons/60058)
- [뉴스 클러스터링](https://programmers.co.kr/learn/courses/30/lessons/17677)

---

### 📝 간단한 풀이 과정

#### 메뉴 리뉴얼

- `{단품 메뉴 수: {메뉴 조합: count}}` 형식으로 각각의 조합이 주문된 횟수를 셉니다.
- 각각의 주문 길이 이하만큼, combinations로 모든 조합을 만들어 counter에 반영합니다.
- counter에서 메뉴 수마다 최댓값을 가진 조합을 리스트에 담는다. 단, 최댓값이 1 이하이면 제외합니다.

#### 괄호 변환

- '('을 1, ')'을 0으로 보고, 이진수로 변환해서 풀었습니다. 둘로 나누거나 뒤집는 연산을 쉽게 하기 위해 그랬는데, 풀고 나니 효율적인지는 모르겠습니다.
- 주어진 p를 이진수로 변환하고, `convert` 함수가 올바른 괄호로 고칩니다.
- `is_right` 함수는 stack을 이용해서 `올바른 괄호 문자열`인지 검사합니다. 빈 stack에 0이 들어오거나 마지막에 stack이 비어있지 않다면 False입니다.
- `find_u` 함수로 p에서 u를 찾습니다. 구한 u의 길이를 이용해 나머지 v를 구합니다.
- `reverse` 함수는 XOR 연산을 통해 이진수를 뒤집습니다.
- 문제의 지시를 따라 `convert`를 재귀적으로 호출합니다.

#### 뉴스 클러스터링

- `re.findall`으로 모든 알파벳 pair를 찾습니다. 그냥 findall 하면 각 문자가 한 번씩 밖에 검색되지 않아서, [링크](https://stackoverflow.com/questions/5616822/python-regex-find-all-overlapping-matches)를 참고했습니다. lookahead 패턴을 이용하면 된다고 합니다.
- 다중집합을 Counter로 표현합니다. str1과 str2는 각각 `set1`, `set2`가 됩니다.
- 두 다중집합의 중복 원소를 제거한 합집합을 순회하면서, 두 집합이 해당 pair 개수를 몇 개씩 포함하고 있는지 구합니다. 두 개수의 최솟값은 교집합 크기에, 최댓값은 합집합 크기에 더합니다.
- 두 다중집합이 모두 비었을 때만 합집합 크기가 0입니다. 합집합 크기가 0일 때는 1, 나머지는 `교집합 크기 / 합집합 크기`를 자카드 유사도로 합니다.
- 65536을 곱해서 리턴합니다.
